### PR TITLE
Game Metadata Editing & Playtime Filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -226,7 +226,6 @@ __marimo__/
 .streamlit/secrets.toml
 
 # AI and dev tools
-.claude/CLAUDE.md
-.claude/settings.local.json
+.claude/
 .github/copilot-instructions.md
 .vscode/settings.json

--- a/.gitignore
+++ b/.gitignore
@@ -224,3 +224,9 @@ __marimo__/
 
 # Streamlit
 .streamlit/secrets.toml
+
+# AI and dev tools
+.claude/CLAUDE.md
+.claude/settings.local.json
+.github/copilot-instructions.md
+.vscode/settings.json

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -89,3 +89,34 @@ All fields are optional:
 ```
 
 After syncing local games, run "Sync Missing Metadata" to fetch cover images, ratings, and other data from IGDB.
+
+---
+
+## Metadata Overrides
+
+You can manually override two metadata fields on any game, directly from the UI. These overrides are **never overwritten by store syncs or IGDB sync**.
+
+### Genres Override
+
+Replaces the store/IGDB-provided genres with a custom list.
+
+- **Library view**: click the pencil icon (✏) on any game card, or select multiple games and click "Edit Metadata" in the action bar
+- **Game detail page**: click "Edit Metadata" next to the "+ Add to Collection" button
+- Type to search and add tags; existing genres are suggested via autocomplete
+- Leave the field empty to reset to the original store/IGDB genres
+
+### Playtime Label
+
+Assigns an explicit playtime status to a game, independently of the numeric hours reported by stores.
+
+Available labels:
+
+| Label | Meaning | Auto-derived from hours when no label is set |
+|---|---|---|
+| `Not played` | Never launched | `playtime_hours` is 0 or missing |
+| `Just tried` | A few minutes to 2 hours | `0 < hours ≤ 2` |
+| `Played` | Played for a while | `2 < hours ≤ 20` |
+| `Heavily played` | Many hours logged | `hours > 20` |
+| `Abandoned` | Started but gave up | *(explicit only)* |
+
+The label can be set via the same edit modal as genres. When no explicit label is set, the game detail page derives and displays a label from the raw `playtime_hours` value.

--- a/docs/project-info.md
+++ b/docs/project-info.md
@@ -4,7 +4,7 @@
 
 | Layer | Technology |
 |-------|-----------|
-| **Backend** | Flask (Python) |
+| **Backend** | FastAPI (Python) |
 | **Database** | SQLite |
 | **Frontend** | Jinja2 templates, vanilla JavaScript |
 | **Metadata** | IGDB API integration, Metacritic, ProtonDB |

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+# Development / testing dependencies
+pytest
+httpx

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,124 @@
+"""conftest.py – shared pytest fixtures for Backlogia tests."""
+
+import json
+import sqlite3
+import pytest
+
+from fastapi.testclient import TestClient
+
+
+def _create_schema(conn: sqlite3.Connection) -> None:
+    """Create the minimal games schema used in tests."""
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS games (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            store TEXT,
+            store_id TEXT,
+            genres TEXT,          -- JSON array
+            genres_override TEXT, -- JSON array (user override)
+            playtime_label TEXT,  -- unplayed/tried/played/heavily_played/abandoned
+            playtime_hours REAL,
+            hidden BOOLEAN DEFAULT 0,
+            removed BOOLEAN DEFAULT 0,
+            nsfw BOOLEAN DEFAULT 0,
+            cover_image TEXT,
+            cover_url_override TEXT,
+            igdb_id INTEGER,
+            igdb_slug TEXT,
+            igdb_rating REAL,
+            aggregated_rating REAL,
+            total_rating REAL,
+            igdb_cover_url TEXT,
+            igdb_screenshots TEXT,
+            igdb_summary TEXT,
+            igdb_matched_at TIMESTAMP,
+            metacritic_score INTEGER,
+            metacritic_user_score REAL,
+            metacritic_slug TEXT,
+            metacritic_url TEXT,
+            protondb_tier TEXT,
+            protondb_total INTEGER,
+            steam_app_id TEXT,
+            average_rating REAL,
+            description TEXT,
+            release_date TEXT,
+            developers TEXT,
+            publishers TEXT,
+            supported_platforms TEXT,
+            extra_data TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+
+        CREATE TABLE IF NOT EXISTS collections (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            description TEXT,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+
+        CREATE TABLE IF NOT EXISTS collection_games (
+            collection_id INTEGER NOT NULL,
+            game_id INTEGER NOT NULL,
+            added_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (collection_id, game_id),
+            FOREIGN KEY (collection_id) REFERENCES collections(id) ON DELETE CASCADE,
+            FOREIGN KEY (game_id) REFERENCES games(id) ON DELETE CASCADE
+        );
+
+        CREATE TABLE IF NOT EXISTS background_jobs (
+            id TEXT PRIMARY KEY,
+            type TEXT,
+            status TEXT,
+            started_at TIMESTAMP,
+            finished_at TIMESTAMP,
+            result TEXT
+        );
+    """)
+
+
+@pytest.fixture
+def db_conn():
+    """In-memory SQLite connection with the games schema pre-created."""
+    conn = sqlite3.connect(":memory:", check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    _create_schema(conn)
+    yield conn
+    conn.close()
+
+
+@pytest.fixture
+def sample_games(db_conn: sqlite3.Connection):
+    """Insert a small set of sample games and return their IDs."""
+    cursor = db_conn.cursor()
+    cursor.executemany(
+        """INSERT INTO games (name, store, store_id, genres, genres_override, playtime_label)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        [
+            ("Half-Life 2", "steam", "220", json.dumps(["Action", "Shooter"]), None, None),
+            ("The Witcher 3", "gog", "1207664643", json.dumps(["RPG", "Adventure"]), None, None),
+            ("Celeste", "epic", "celeste", json.dumps(["Platformer", "Indie"]), None, "heavily_played"),
+        ],
+    )
+    db_conn.commit()
+    cursor.execute("SELECT id FROM games ORDER BY id")
+    ids = [row[0] for row in cursor.fetchall()]
+    return ids
+
+
+@pytest.fixture
+def client(db_conn: sqlite3.Connection, sample_games):  # noqa: F811
+    """TestClient with the get_db dependency overridden to use in-memory DB."""
+    # Import here so DATABASE_PATH patching in main doesn't break other tests
+    from web.main import app
+    from web.dependencies import get_db
+
+    def override_get_db():
+        yield db_conn
+
+    app.dependency_overrides[get_db] = override_get_db
+    with TestClient(app) as tc:
+        yield tc
+    app.dependency_overrides.clear()

--- a/tests/test_game_edit.py
+++ b/tests/test_game_edit.py
@@ -1,0 +1,235 @@
+"""tests/test_game_edit.py
+
+Unit / integration tests for the game metadata edit feature.
+
+Covered endpoints:
+  GET  /api/genres
+  POST /api/games/bulk/edit
+"""
+
+import json
+
+
+# --------------------------------------------------------------------------- #
+# GET /api/genres                                                              #
+# --------------------------------------------------------------------------- #
+
+
+class TestApiGenres:
+    def test_returns_list(self, client):
+        """Endpoint returns a JSON array."""
+        resp = client.get("/api/genres")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert isinstance(body, list)
+
+    def test_returns_sorted_unique_genres(self, client):
+        """Genres are sorted and de-duplicated."""
+        body = client.get("/api/genres").json()
+        assert body == sorted(set(body))
+
+    def test_includes_store_genres(self, client, sample_games, db_conn):
+        """Genres from the store-provided 'genres' column are included."""
+        body = client.get("/api/genres").json()
+        # Sample games contain: Action, Shooter, RPG, Adventure, Platformer, Indie
+        for genre in ("Action", "Shooter", "RPG", "Adventure", "Platformer", "Indie"):
+            assert genre in body
+
+    def test_includes_override_genres(self, client, sample_games, db_conn):
+        """Genres from 'genres_override' are also included."""
+        game_id = sample_games[0]
+        db_conn.execute(
+            "UPDATE games SET genres_override = ? WHERE id = ?",
+            (json.dumps(["Custom Genre"]), game_id),
+        )
+        db_conn.commit()
+
+        body = client.get("/api/genres").json()
+        assert "Custom Genre" in body
+
+    def test_excludes_hidden_games(self, client, sample_games, db_conn):
+        """Hidden games' genres should NOT appear (uses EXCLUDE_HIDDEN_FILTER)."""
+        # Add a hidden game with a unique genre
+        db_conn.execute(
+            "INSERT INTO games (name, store, genres, hidden) VALUES (?, ?, ?, ?)",
+            ("Hidden Game", "steam", json.dumps(["SecretGenre"]), 1),
+        )
+        db_conn.commit()
+
+        body = client.get("/api/genres").json()
+        assert "SecretGenre" not in body
+
+
+# --------------------------------------------------------------------------- #
+# POST /api/games/bulk/edit                                                    #
+# --------------------------------------------------------------------------- #
+
+
+class TestBulkEdit:
+    def test_update_genres_override(self, client, sample_games, db_conn):
+        """genres_override is written when update_genres_override=True."""
+        game_id = sample_games[0]
+        resp = client.post(
+            "/api/games/bulk/edit",
+            json={
+                "game_ids": [game_id],
+                "genres_override": ["Narrative", "Indie"],
+                "update_genres_override": True,
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
+
+        row = db_conn.execute(
+            "SELECT genres_override FROM games WHERE id = ?", (game_id,)
+        ).fetchone()
+        assert json.loads(row[0]) == ["Narrative", "Indie"]
+
+    def test_update_playtime_label(self, client, sample_games, db_conn):
+        """playtime_label is written when update_playtime_label=True."""
+        game_id = sample_games[1]
+        resp = client.post(
+            "/api/games/bulk/edit",
+            json={
+                "game_ids": [game_id],
+                "playtime_label": "played",
+                "update_playtime_label": True,
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json()["success"] is True
+
+        row = db_conn.execute(
+            "SELECT playtime_label FROM games WHERE id = ?", (game_id,)
+        ).fetchone()
+        assert row[0] == "played"
+
+    def test_update_both_fields(self, client, sample_games, db_conn):
+        """Both fields can be updated in a single request."""
+        game_id = sample_games[0]
+        resp = client.post(
+            "/api/games/bulk/edit",
+            json={
+                "game_ids": [game_id],
+                "genres_override": ["Strategy"],
+                "update_genres_override": True,
+                "playtime_label": "heavily_played",
+                "update_playtime_label": True,
+            },
+        )
+        assert resp.status_code == 200
+
+        row = db_conn.execute(
+            "SELECT genres_override, playtime_label FROM games WHERE id = ?", (game_id,)
+        ).fetchone()
+        assert json.loads(row[0]) == ["Strategy"]
+        assert row[1] == "heavily_played"
+
+    def test_clear_genres_override(self, client, sample_games, db_conn):
+        """Passing genres_override=None with the flag clears the stored value."""
+        game_id = sample_games[0]
+        db_conn.execute(
+            "UPDATE games SET genres_override = ? WHERE id = ?",
+            (json.dumps(["OldGenre"]), game_id),
+        )
+        db_conn.commit()
+
+        resp = client.post(
+            "/api/games/bulk/edit",
+            json={
+                "game_ids": [game_id],
+                "genres_override": None,
+                "update_genres_override": True,
+            },
+        )
+        assert resp.status_code == 200
+
+        row = db_conn.execute(
+            "SELECT genres_override FROM games WHERE id = ?", (game_id,)
+        ).fetchone()
+        assert row[0] is None
+
+    def test_clear_playtime_label(self, client, sample_games, db_conn):
+        """Passing playtime_label=None with the flag clears the stored label."""
+        game_id = sample_games[2]  # Celeste already has playtime_label="heavily_played"
+
+        resp = client.post(
+            "/api/games/bulk/edit",
+            json={
+                "game_ids": [game_id],
+                "playtime_label": None,
+                "update_playtime_label": True,
+            },
+        )
+        assert resp.status_code == 200
+
+        row = db_conn.execute(
+            "SELECT playtime_label FROM games WHERE id = ?", (game_id,)
+        ).fetchone()
+        assert row[0] is None
+
+    def test_bulk_update_multiple_games(self, client, sample_games, db_conn):
+        """All listed game IDs are updated in a single call."""
+        resp = client.post(
+            "/api/games/bulk/edit",
+            json={
+                "game_ids": sample_games,
+                "playtime_label": "tried",
+                "update_playtime_label": True,
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json()["updated"] == len(sample_games)
+
+    def test_invalid_playtime_label_returns_422(self, client, sample_games):
+        """An unrecognised playtime label produces a 422 error."""
+        resp = client.post(
+            "/api/games/bulk/edit",
+            json={
+                "game_ids": [sample_games[0]],
+                "playtime_label": "immortal",
+                "update_playtime_label": True,
+            },
+        )
+        assert resp.status_code == 422
+
+    def test_empty_game_ids_returns_400(self, client):
+        """Passing an empty game_ids list produces a 400 error."""
+        resp = client.post(
+            "/api/games/bulk/edit",
+            json={
+                "game_ids": [],
+                "playtime_label": "played",
+                "update_playtime_label": True,
+            },
+        )
+        assert resp.status_code == 400
+
+    def test_no_update_flags_returns_400(self, client, sample_games):
+        """If neither update flag is set, the server returns 400."""
+        resp = client.post(
+            "/api/games/bulk/edit",
+            json={"game_ids": [sample_games[0]]},
+        )
+        assert resp.status_code == 400
+
+    def test_untouched_fields_are_not_overwritten(self, client, sample_games, db_conn):
+        """Updating genres_override does not affect playtime_label and vice-versa."""
+        game_id = sample_games[2]  # Celeste has playtime_label="heavily_played"
+        original_label = db_conn.execute(
+            "SELECT playtime_label FROM games WHERE id = ?", (game_id,)
+        ).fetchone()[0]
+
+        client.post(
+            "/api/games/bulk/edit",
+            json={
+                "game_ids": [game_id],
+                "genres_override": ["Platformer"],
+                "update_genres_override": True,
+            },
+        )
+
+        row = db_conn.execute(
+            "SELECT playtime_label FROM games WHERE id = ?", (game_id,)
+        ).fetchone()
+        assert row[0] == original_label  # unchanged

--- a/web/database.py
+++ b/web/database.py
@@ -35,6 +35,24 @@ def ensure_extra_columns():
     conn.close()
 
 
+def ensure_edit_overrides():
+    """Add genres_override and playtime_label columns to the games table."""
+    conn = sqlite3.connect(DATABASE_PATH)
+    cursor = conn.cursor()
+    cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='games'")
+    if not cursor.fetchone():
+        conn.close()
+        return
+    cursor.execute("PRAGMA table_info(games)")
+    columns = {row[1] for row in cursor.fetchall()}
+    if "genres_override" not in columns:
+        cursor.execute("ALTER TABLE games ADD COLUMN genres_override TEXT")
+    if "playtime_label" not in columns:
+        cursor.execute("ALTER TABLE games ADD COLUMN playtime_label TEXT")
+    conn.commit()
+    conn.close()
+
+
 def ensure_collections_tables():
     """Create collections tables if they don't exist."""
     conn = sqlite3.connect(DATABASE_PATH)

--- a/web/main.py
+++ b/web/main.py
@@ -11,7 +11,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
 from .config import DATABASE_PATH, ENABLE_AUTH, SECRET_KEY
-from .database import ensure_extra_columns, ensure_collections_tables
+from .database import ensure_extra_columns, ensure_collections_tables, ensure_edit_overrides
 from .services.database_builder import create_database
 from .services.igdb_sync import add_igdb_columns
 from .services.jobs import cleanup_orphaned_jobs
@@ -34,6 +34,7 @@ def init_database():
     create_database()
     ensure_extra_columns()
     ensure_collections_tables()
+    ensure_edit_overrides()
 
     conn = sqlite3.connect(DATABASE_PATH)
     add_igdb_columns(conn)

--- a/web/routes/api_games.py
+++ b/web/routes/api_games.py
@@ -1,12 +1,13 @@
 # routes/api_games.py
 # API endpoints for games data
 
+import json
 import sqlite3
 
 from fastapi import APIRouter, Depends
 
 from ..dependencies import get_db
-from ..utils.filters import EXCLUDE_DUPLICATES_FILTER
+from ..utils.filters import EXCLUDE_DUPLICATES_FILTER, EXCLUDE_HIDDEN_FILTER
 
 router = APIRouter(tags=["Games"])
 
@@ -41,3 +42,32 @@ def api_stats(conn: sqlite3.Connection = Depends(get_db)):
         "by_store": by_store,
         "total_playtime_hours": round(total_playtime, 1)
     }
+
+
+@router.get("/api/genres")
+def api_genres(conn: sqlite3.Connection = Depends(get_db)):
+    """Get all distinct genres present in the library.
+
+    Merges genres from the store-provided ``genres`` column and from the
+    user-defined ``genres_override`` column, returning a sorted, de-duplicated
+    list of genre names.
+    """
+    cursor = conn.cursor()
+    cursor.execute(
+        "SELECT genres, genres_override FROM games WHERE 1=1" + EXCLUDE_HIDDEN_FILTER
+    )
+    rows = cursor.fetchall()
+
+    genres_set: set[str] = set()
+    for row in rows:
+        for field in (row[0], row[1]):
+            if not field:
+                continue
+            try:
+                items = json.loads(field)
+                if isinstance(items, list):
+                    genres_set.update(str(g).strip() for g in items if g)
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+    return sorted(genres_set)

--- a/web/routes/api_metadata.py
+++ b/web/routes/api_metadata.py
@@ -50,6 +50,25 @@ class BulkAddToCollectionRequest(BaseModel):
     collection_id: int
 
 
+PLAYTIME_LABELS = {"unplayed", "tried", "played", "heavily_played", "abandoned"}
+
+
+class BulkEditRequest(BaseModel):
+    """Request body for the bulk-edit endpoint.
+
+    Fields that the user did not interact with should not be sent (or sent as
+    ``None``).  Set the companion ``update_*`` flag to ``True`` to actually
+    write the value to the database (this lets the caller distinguish "not
+    touched" from "explicitly cleared").
+    """
+
+    game_ids: list[int]
+    genres_override: Optional[list[str]] = None
+    update_genres_override: bool = False
+    playtime_label: Optional[str] = None
+    update_playtime_label: bool = False
+
+
 @router.post("/api/game/{game_id}/igdb")
 def update_igdb(game_id: int, body: UpdateIgdbRequest, conn: sqlite3.Connection = Depends(get_db)):
     """Update IGDB ID for a game."""
@@ -435,6 +454,55 @@ def recalculate_average_ratings(conn: sqlite3.Connection = Depends(get_db)):
 
     conn.commit()
     return {"success": True, "updated": updated, "message": f"Recalculated average ratings for {updated} games"}
+
+
+@router.post("/api/games/bulk/edit")
+def bulk_edit_games(body: BulkEditRequest, conn: sqlite3.Connection = Depends(get_db)):
+    """Edit metadata overrides for one or more games.
+
+    Only fields whose companion ``update_*`` flag is ``True`` are written.
+    Passing ``None`` with the flag set to ``True`` clears the stored value.
+    """
+    import json as _json
+
+    game_ids = body.game_ids
+    if not game_ids:
+        raise HTTPException(status_code=400, detail="No games selected")
+
+    # Validate playtime_label when provided
+    if body.update_playtime_label and body.playtime_label is not None:
+        if body.playtime_label not in PLAYTIME_LABELS:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Invalid playtime_label. Must be one of: {', '.join(sorted(PLAYTIME_LABELS))}",
+            )
+
+    if not body.update_genres_override and not body.update_playtime_label:
+        raise HTTPException(status_code=400, detail="Nothing to update")
+
+    cursor = conn.cursor()
+    placeholders = ",".join("?" * len(game_ids))
+    set_clauses: list[str] = []
+    params: list = []
+
+    if body.update_genres_override:
+        genres_json = _json.dumps(body.genres_override) if body.genres_override is not None else None
+        set_clauses.append("genres_override = ?")
+        params.append(genres_json)
+
+    if body.update_playtime_label:
+        set_clauses.append("playtime_label = ?")
+        params.append(body.playtime_label)
+
+    params.extend(game_ids)
+    cursor.execute(
+        f"UPDATE games SET {', '.join(set_clauses)} WHERE id IN ({placeholders})",
+        params,
+    )
+    updated = cursor.rowcount
+    conn.commit()
+
+    return {"success": True, "updated": updated}
 
 
 @router.post("/api/games/bulk/hide")

--- a/web/routes/api_metadata.py
+++ b/web/routes/api_metadata.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from ..dependencies import get_db
+from ..utils.filters import PLAYTIME_LABELS
 
 router = APIRouter(tags=["Metadata"])
 
@@ -48,9 +49,6 @@ class BulkGameIdsRequest(BaseModel):
 class BulkAddToCollectionRequest(BaseModel):
     game_ids: list[int]
     collection_id: int
-
-
-PLAYTIME_LABELS = {"unplayed", "tried", "played", "heavily_played", "abandoned"}
 
 
 class BulkEditRequest(BaseModel):
@@ -463,8 +461,6 @@ def bulk_edit_games(body: BulkEditRequest, conn: sqlite3.Connection = Depends(ge
     Only fields whose companion ``update_*`` flag is ``True`` are written.
     Passing ``None`` with the flag set to ``True`` clears the stored value.
     """
-    import json as _json
-
     game_ids = body.game_ids
     if not game_ids:
         raise HTTPException(status_code=400, detail="No games selected")
@@ -486,7 +482,7 @@ def bulk_edit_games(body: BulkEditRequest, conn: sqlite3.Connection = Depends(ge
     params: list = []
 
     if body.update_genres_override:
-        genres_json = _json.dumps(body.genres_override) if body.genres_override is not None else None
+        genres_json = json.dumps(body.genres_override) if body.genres_override is not None else None
         set_clauses.append("genres_override = ?")
         params.append(genres_json)
 

--- a/web/routes/library.py
+++ b/web/routes/library.py
@@ -52,12 +52,10 @@ def library(
         params.extend(stores)
 
     if genres:
-        # Filter by genres (JSON array stored in genres column)
-        # Use LIKE with JSON pattern matching for each genre
+        # Filter by genres, preferring genres_override if set
         genre_conditions = []
         for genre in genres:
-            # Match genre in JSON array (case-insensitive)
-            genre_conditions.append("LOWER(genres) LIKE ?")
+            genre_conditions.append("LOWER(COALESCE(genres_override, genres)) LIKE ?")
             params.append(f'%"{genre.lower()}"%')
         query += " AND (" + " OR ".join(genre_conditions) + ")"
 
@@ -123,7 +121,21 @@ def library(
         sort = "name"
     if sort in available_sorts:
         order_dir = "DESC" if order == "desc" else "ASC"
-        if sort in ["playtime_hours", "critics_score", "total_rating", "igdb_rating", "aggregated_rating", "average_rating", "metacritic_score", "metacritic_user_score"]:
+        if sort == "playtime_hours":
+            # Respect manual playtime_label when playtime_hours is NULL:
+            # COALESCE tries hours first, then falls back to a sentinel derived from the label.
+            query += f""" ORDER BY COALESCE(
+                playtime_hours,
+                CASE playtime_label
+                    WHEN 'heavily_played' THEN 1000
+                    WHEN 'abandoned'      THEN 50
+                    WHEN 'played'         THEN 11
+                    WHEN 'tried'          THEN 1
+                    WHEN 'unplayed'       THEN 0
+                    ELSE NULL
+                END
+            ) {order_dir} NULLS LAST"""
+        elif sort in ["critics_score", "total_rating", "igdb_rating", "aggregated_rating", "average_rating", "metacritic_score", "metacritic_user_score"]:
             query += f" ORDER BY {sort} {order_dir} NULLS LAST"
         else:
             query += f" ORDER BY {sort} COLLATE NOCASE {order_dir}"
@@ -141,18 +153,35 @@ def library(
     # Sort grouped games by primary game's sort field
     # Separate games with null sort values so nulls are always last
     reverse = order == "desc"
+
+    _PLAYTIME_LABEL_SENTINEL = {
+        "heavily_played": 1000,
+        "abandoned": 50,
+        "played": 11,
+        "tried": 1,
+        "unplayed": 0,
+    }
+
+    def effective_sort_value(game: dict, field: str):
+        """Return the value used for sorting, applying label-based fallback for playtime_hours."""
+        val = game.get(field)
+        if field == "playtime_hours" and val is None:
+            label = game.get("playtime_label")
+            val = _PLAYTIME_LABEL_SENTINEL.get(label)  # None if no label
+        return val
+
     with_values = []
     without_values = []
 
     for g in grouped_games:
-        val = g["primary"].get(sort)
+        val = effective_sort_value(g["primary"], sort)
         if val is None:
             without_values.append(g)
         else:
             with_values.append(g)
 
     def get_sort_key(g):
-        val = g["primary"].get(sort)
+        val = effective_sort_value(g["primary"], sort)
         if isinstance(val, str):
             return val.lower()
         return val
@@ -188,8 +217,8 @@ def library(
     """)
     collections = [{"id": row[0], "name": row[1], "game_count": row[2]} for row in cursor.fetchall()]
 
-    # Get all unique genres with counts
-    cursor.execute("SELECT genres FROM games WHERE genres IS NOT NULL AND genres != '[]'" + EXCLUDE_HIDDEN_FILTER)
+    # Get all unique genres with counts, preferring genres_override if set
+    cursor.execute("SELECT COALESCE(genres_override, genres) FROM games WHERE COALESCE(genres_override, genres) IS NOT NULL AND COALESCE(genres_override, genres) != '[]'" + EXCLUDE_HIDDEN_FILTER)
     genre_rows = cursor.fetchall()
     genre_counts = {}
     for row in genre_rows:

--- a/web/routes/library.py
+++ b/web/routes/library.py
@@ -36,6 +36,7 @@ def library(
     collection: int = 0,
     protondb_tier: str = "",
     no_igdb: bool = False,
+    playtime_label: list[str] = Query(default=[]),
     conn: sqlite3.Connection = Depends(get_db)
 ):
     """Library page - list all games."""
@@ -81,6 +82,37 @@ def library(
     # No IGDB data filter
     if no_igdb:
         query += " AND (igdb_id IS NULL OR igdb_id = 0)"
+
+    # Playtime label filter – supports multiple values; unplayed/tried/played
+    # also match games with no explicit label using playtime_hours ranges.
+    VALID_PLAYTIME_LABELS = {"unplayed", "tried", "played", "heavily_played", "abandoned"}
+    active_labels = [l for l in playtime_label if l in VALID_PLAYTIME_LABELS]
+    if active_labels:
+        label_conditions: list[str] = []
+        for lbl in active_labels:
+            if lbl == "unplayed":
+                label_conditions.append(
+                    "(playtime_label = 'unplayed' OR "
+                    "(playtime_label IS NULL AND (playtime_hours IS NULL OR playtime_hours = 0)))"
+                )
+            elif lbl == "tried":
+                label_conditions.append(
+                    "(playtime_label = 'tried' OR "
+                    "(playtime_label IS NULL AND playtime_hours > 0 AND playtime_hours <= 2))"
+                )
+            elif lbl == "played":
+                label_conditions.append(
+                    "(playtime_label = 'played' OR "
+                    "(playtime_label IS NULL AND playtime_hours > 2 AND playtime_hours <= 20))"
+                )
+            elif lbl == "heavily_played":
+                label_conditions.append(
+                    "(playtime_label = 'heavily_played' OR "
+                    "(playtime_label IS NULL AND playtime_hours > 20))"
+                )
+            else:  # abandoned – explicit label only
+                label_conditions.append(f"playtime_label = '{lbl}'")
+        query += " AND (" + " OR ".join(label_conditions) + ")"
 
     # Sorting - detect which columns actually exist in the DB
     cursor.execute("PRAGMA table_info(games)")
@@ -191,6 +223,7 @@ def library(
             "current_collection": collection,
             "current_protondb_tier": protondb_tier,
             "current_no_igdb": no_igdb,
+            "current_playtime_labels": playtime_label,
             "collections": collections,
             "available_sorts": available_sorts,
             "parse_json": parse_json_field

--- a/web/routes/library.py
+++ b/web/routes/library.py
@@ -11,7 +11,7 @@ from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 
 from ..dependencies import get_db
-from ..utils.filters import EXCLUDE_HIDDEN_FILTER, EXCLUDE_DUPLICATES_FILTER
+from ..utils.filters import EXCLUDE_HIDDEN_FILTER, EXCLUDE_DUPLICATES_FILTER, PLAYTIME_LABELS
 from ..utils.helpers import parse_json_field, get_store_url, group_games_by_igdb
 
 router = APIRouter()
@@ -83,8 +83,7 @@ def library(
 
     # Playtime label filter – supports multiple values; unplayed/tried/played
     # also match games with no explicit label using playtime_hours ranges.
-    VALID_PLAYTIME_LABELS = {"unplayed", "tried", "played", "heavily_played", "abandoned"}
-    active_labels = [l for l in playtime_label if l in VALID_PLAYTIME_LABELS]
+    active_labels = [l for l in playtime_label if l in PLAYTIME_LABELS]
     if active_labels:
         label_conditions: list[str] = []
         for lbl in active_labels:

--- a/web/static/js/edit_modal.js
+++ b/web/static/js/edit_modal.js
@@ -223,6 +223,18 @@
     font-weight: 600;
     box-shadow: 0 0 0 1px currentColor;
 }
+/* Suggested (auto-derived from hours) — dashed border, no fill */
+.em-playtime-btn.suggested {
+    border-style: dashed;
+    opacity: 0.75;
+    font-style: italic;
+}
+.em-playtime-btn.suggested::after {
+    content: ' · auto';
+    font-size: 0.75em;
+    opacity: 0.65;
+    font-style: normal;
+}
 .em-playtime-clear {
     background: rgba(244,67,54,0.1);
     color: #f44336;
@@ -335,6 +347,7 @@
     let _originalTagsJSON   = null; // to detect changes
     let _selectedLabel      = null; // working copy for playtime_label
     let _originalLabel      = null; // to detect changes
+    let _playtimeHours      = null; // store value, used to derive suggested label
     let _autocompleteHi     = -1;   // highlighted index in dropdown
 
     /* ------------------------------------------------------------------ */
@@ -364,6 +377,7 @@
         // Resolve initial playtime label
         _selectedLabel  = currentData.playtime_label || null;
         _originalLabel  = _selectedLabel;
+        _playtimeHours  = (currentData.playtime_hours != null) ? parseFloat(currentData.playtime_hours) : null;
 
         // Update title
         const n = _gameIds.length;
@@ -387,9 +401,10 @@
         renderPlaytimeButtons();
 
         // Show store playtime if single game
+        // Show store playtime if single game (renderPlaytimeButtons will add suggestion text)
         const storePt = document.getElementById('em-store-playtime');
-        if (_gameIds.length === 1 && currentData.playtime_hours) {
-            storePt.textContent = `Store value: ${parseFloat(currentData.playtime_hours).toFixed(1)} h`;
+        if (_gameIds.length === 1 && _playtimeHours != null) {
+            storePt.textContent = `Store value: ${_playtimeHours.toFixed(1)} h`;
         } else {
             storePt.textContent = '';
         }
@@ -534,18 +549,43 @@
     /* Playtime                                                             */
     /* ------------------------------------------------------------------ */
 
+    function derivedLabelFromHours(hours) {
+        if (hours == null) return null;
+        if (hours === 0)   return 'unplayed';
+        if (hours <= 2)    return 'tried';
+        if (hours <= 20)   return 'played';
+        return 'heavily_played';
+    }
+
     function renderPlaytimeButtons() {
         const grid = document.getElementById('em-playtime-grid');
         grid.innerHTML = '';
 
+        // Suggested label: only shown when no manual selection is active
+        const suggested = (_selectedLabel === null) ? derivedLabelFromHours(_playtimeHours) : null;
+
         PLAYTIME_LABELS.forEach(label => {
-            const c = PLAYTIME_COLORS[label];
+            const c   = PLAYTIME_COLORS[label];
+            const isActive    = label === _selectedLabel;
+            const isSuggested = !isActive && label === suggested;
             const btn = document.createElement('button');
-            btn.className = 'em-playtime-btn' + (label === _selectedLabel ? ' active' : '');
+            btn.className = 'em-playtime-btn'
+                + (isActive    ? ' active'    : '')
+                + (isSuggested ? ' suggested' : '');
             btn.textContent = PLAYTIME_DISPLAY[label] || label;
-            btn.style.background   = label === _selectedLabel ? c.bg : 'rgba(255,255,255,0.05)';
-            btn.style.borderColor  = label === _selectedLabel ? c.border : 'rgba(255,255,255,0.1)';
-            btn.style.color        = label === _selectedLabel ? c.text : '#888';
+            if (isActive) {
+                btn.style.background  = c.bg;
+                btn.style.borderColor = c.border;
+                btn.style.color       = c.text;
+            } else if (isSuggested) {
+                btn.style.background  = 'transparent';
+                btn.style.borderColor = c.text;   // dashed via CSS class
+                btn.style.color       = c.text;
+            } else {
+                btn.style.background  = 'rgba(255,255,255,0.05)';
+                btn.style.borderColor = 'rgba(255,255,255,0.1)';
+                btn.style.color       = '#888';
+            }
             btn.onclick = () => {
                 _selectedLabel = (_selectedLabel === label) ? null : label;
                 renderPlaytimeButtons();
@@ -553,13 +593,21 @@
             grid.appendChild(btn);
         });
 
-        // Clear button (only shown when something is set)
+        // Clear button (only shown when something is explicitly set)
         if (_selectedLabel) {
             const clearBtn = document.createElement('button');
             clearBtn.className = 'em-playtime-btn em-playtime-clear';
             clearBtn.textContent = 'Clear';
             clearBtn.onclick = () => { _selectedLabel = null; renderPlaytimeButtons(); };
             grid.appendChild(clearBtn);
+        }
+
+        // Update the hours hint to reflect current suggestion state
+        const storePt = document.getElementById('em-store-playtime');
+        if (storePt && _playtimeHours != null) {
+            const derivedDisplay = suggested ? PLAYTIME_DISPLAY[suggested] : null;
+            storePt.textContent = `Store value: ${_playtimeHours.toFixed(1)} h`
+                + (derivedDisplay ? ` \u2192 "${derivedDisplay}" suggested` : '');
         }
     }
 

--- a/web/static/js/edit_modal.js
+++ b/web/static/js/edit_modal.js
@@ -1,0 +1,647 @@
+/**
+ * edit_modal.js
+ *
+ * Shared "Edit Metadata" modal used by the library view (bulk) and the game
+ * detail page (single game).
+ *
+ * Public API:
+ *   window.openEditModal(gameIds, currentData)
+ *
+ * @param {number|number[]} gameIds      One game ID or an array of IDs.
+ * @param {object}          currentData  Optional snapshot of the game(s).
+ *   currentData.genres_override  – JSON-parsed array or null
+ *   currentData.genres           – JSON-parsed array or null  (store value)
+ *   currentData.playtime_label   – string or null
+ *   currentData.playtime_hours   – number or null (shown read-only)
+ */
+
+(function () {
+    'use strict';
+
+    /* ------------------------------------------------------------------ */
+    /* Constants                                                            */
+    /* ------------------------------------------------------------------ */
+
+    const PLAYTIME_LABELS = ['unplayed', 'tried', 'played', 'heavily_played', 'abandoned'];
+    const PLAYTIME_COLORS = {
+        unplayed:       { bg: 'rgba(136,136,136,0.2)',  border: 'rgba(136,136,136,0.4)',  text: '#888'    },
+        tried:          { bg: 'rgba(33,150,243,0.2)',   border: 'rgba(33,150,243,0.4)',   text: '#2196f3' },
+        played:         { bg: 'rgba(76,175,80,0.2)',    border: 'rgba(76,175,80,0.4)',    text: '#4caf50' },
+        heavily_played: { bg: 'rgba(156,39,176,0.2)',   border: 'rgba(156,39,176,0.4)',   text: '#9c27b0' },
+        abandoned:      { bg: 'rgba(244,67,54,0.2)',    border: 'rgba(244,67,54,0.4)',    text: '#f44336' },
+    };
+    const PLAYTIME_DISPLAY = {
+        unplayed:       'Not played',
+        tried:          'Just tried',
+        played:         'Played',
+        heavily_played: 'Heavily played',
+        abandoned:      'Abandoned',
+    };
+
+    let cachedGenres = null;   // fetched once from /api/genres
+
+    /* ------------------------------------------------------------------ */
+    /* CSS injection                                                        */
+    /* ------------------------------------------------------------------ */
+
+    function injectStyles() {
+        if (document.getElementById('edit-modal-styles')) return;
+        const style = document.createElement('style');
+        style.id = 'edit-modal-styles';
+        style.textContent = `
+/* ---- overlay ---- */
+#edit-modal-overlay {
+    display: none;
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.75);
+    z-index: 2000;
+    justify-content: center;
+    align-items: center;
+}
+#edit-modal-overlay.active { display: flex; }
+
+/* ---- modal box (desktop) ---- */
+#edit-modal {
+    background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+    border: 1px solid rgba(255,255,255,0.12);
+    border-radius: 16px;
+    padding: 28px;
+    width: 90%;
+    max-width: 480px;
+    max-height: 85vh;
+    overflow-y: auto;
+    box-shadow: 0 20px 60px rgba(0,0,0,0.6);
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 22px;
+}
+
+/* ---- mobile bottom sheet ---- */
+@media (max-width: 768px) {
+    #edit-modal-overlay { align-items: flex-end; }
+    #edit-modal {
+        width: 100%;
+        max-width: 100%;
+        border-radius: 20px 20px 0 0;
+        padding: 20px 20px 32px;
+        max-height: 90vh;
+    }
+}
+
+/* ---- header ---- */
+.em-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+.em-header h2 {
+    margin: 0;
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: #e4e4e4;
+}
+.em-close {
+    background: none;
+    border: none;
+    color: #888;
+    font-size: 1.4rem;
+    cursor: pointer;
+    line-height: 1;
+    padding: 4px;
+    border-radius: 6px;
+    transition: color 0.2s, background 0.2s;
+}
+.em-close:hover { color: #e4e4e4; background: rgba(255,255,255,0.08); }
+
+/* ---- section labels ---- */
+.em-section h3 {
+    margin: 0 0 12px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: #888;
+}
+
+/* ---- tag input ---- */
+.em-tag-area {
+    min-height: 42px;
+    background: rgba(255,255,255,0.05);
+    border: 1px solid rgba(255,255,255,0.1);
+    border-radius: 10px;
+    padding: 6px 10px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    align-items: center;
+    cursor: text;
+    position: relative;
+}
+.em-tag-area:focus-within { border-color: #667eea; }
+.em-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    background: rgba(102,126,234,0.25);
+    border: 1px solid rgba(102,126,234,0.4);
+    border-radius: 6px;
+    padding: 3px 8px;
+    font-size: 0.82rem;
+    color: #c5cbf9;
+}
+.em-tag-remove {
+    background: none;
+    border: none;
+    color: #888;
+    cursor: pointer;
+    font-size: 1rem;
+    line-height: 1;
+    padding: 0;
+}
+.em-tag-remove:hover { color: #f44336; }
+.em-tag-input {
+    background: none;
+    border: none;
+    outline: none;
+    color: #e4e4e4;
+    font-size: 0.9rem;
+    min-width: 120px;
+    flex: 1;
+}
+.em-tag-hint {
+    font-size: 0.78rem;
+    color: #555;
+    margin-top: 6px;
+}
+
+/* ---- autocomplete dropdown ---- */
+.em-autocomplete {
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    right: 0;
+    background: #1a1a2e;
+    border: 1px solid rgba(255,255,255,0.15);
+    border-radius: 8px;
+    max-height: 160px;
+    overflow-y: auto;
+    z-index: 2100;
+    display: none;
+}
+.em-autocomplete.active { display: block; }
+.em-autocomplete-item {
+    padding: 8px 12px;
+    cursor: pointer;
+    font-size: 0.88rem;
+    color: #c4c4c4;
+}
+.em-autocomplete-item:hover,
+.em-autocomplete-item.highlighted { background: rgba(102,126,234,0.25); color: #e4e4e4; }
+
+/* ---- playtime buttons ---- */
+.em-playtime-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+.em-playtime-btn {
+    padding: 7px 14px;
+    border-radius: 8px;
+    border: 1px solid transparent;
+    cursor: pointer;
+    font-size: 0.85rem;
+    text-transform: capitalize;
+    transition: all 0.15s;
+    background: rgba(255,255,255,0.05);
+    color: #888;
+    border-color: rgba(255,255,255,0.1);
+}
+.em-playtime-btn:hover { opacity: 0.85; }
+.em-playtime-btn.active {
+    font-weight: 600;
+    box-shadow: 0 0 0 1px currentColor;
+}
+.em-playtime-clear {
+    background: rgba(244,67,54,0.1);
+    color: #f44336;
+    border-color: rgba(244,67,54,0.25);
+}
+.em-playtime-clear:hover { background: rgba(244,67,54,0.2); }
+.em-store-playtime {
+    margin-top: 8px;
+    font-size: 0.8rem;
+    color: #555;
+}
+
+/* ---- footer ---- */
+.em-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+}
+.em-btn {
+    padding: 10px 22px;
+    border-radius: 10px;
+    border: none;
+    cursor: pointer;
+    font-size: 0.9rem;
+    transition: opacity 0.15s;
+}
+.em-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.em-btn.cancel {
+    background: rgba(255,255,255,0.08);
+    color: #888;
+}
+.em-btn.cancel:hover { background: rgba(255,255,255,0.15); color: #e4e4e4; }
+.em-btn.save {
+    background: linear-gradient(90deg, #667eea, #764ba2);
+    color: #fff;
+}
+.em-btn.save:hover { opacity: 0.9; }
+
+/* ---- status message ---- */
+.em-status {
+    padding: 8px 14px;
+    border-radius: 8px;
+    font-size: 0.85rem;
+    display: none;
+}
+.em-status.success { background: rgba(76,175,80,0.2); color: #4caf50; display: block; }
+.em-status.error   { background: rgba(244,67,54,0.2); color: #f44336; display: block; }
+        `;
+        document.head.appendChild(style);
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* DOM scaffold                                                         */
+    /* ------------------------------------------------------------------ */
+
+    function ensureModalDOM() {
+        if (document.getElementById('edit-modal-overlay')) return;
+        const overlay = document.createElement('div');
+        overlay.id = 'edit-modal-overlay';
+        overlay.innerHTML = `
+<div id="edit-modal" role="dialog" aria-modal="true" aria-labelledby="em-title">
+  <div class="em-header">
+    <h2 id="em-title">Edit Metadata</h2>
+    <button class="em-close" id="em-close-btn" aria-label="Close">&times;</button>
+  </div>
+
+  <section class="em-section" id="em-genres-section">
+    <h3>Genres</h3>
+    <div class="em-tag-area" id="em-tag-area">
+      <input class="em-tag-input" id="em-tag-input" type="text"
+             placeholder="Add genre…" autocomplete="off" spellcheck="false">
+      <div class="em-autocomplete" id="em-autocomplete"></div>
+    </div>
+    <p class="em-tag-hint" id="em-genres-hint"></p>
+  </section>
+
+  <section class="em-section" id="em-playtime-section">
+    <h3>Playtime label</h3>
+    <div class="em-playtime-grid" id="em-playtime-grid"></div>
+    <p class="em-store-playtime" id="em-store-playtime"></p>
+  </section>
+
+  <div class="em-status" id="em-status"></div>
+
+  <div class="em-footer">
+    <button class="em-btn cancel" id="em-cancel-btn">Cancel</button>
+    <button class="em-btn save"   id="em-save-btn">Save</button>
+  </div>
+</div>
+        `;
+        document.body.appendChild(overlay);
+
+        // Close events
+        overlay.addEventListener('click', function (e) {
+            if (e.target === overlay) closeEditModal();
+        });
+        document.getElementById('em-close-btn').addEventListener('click', closeEditModal);
+        document.getElementById('em-cancel-btn').addEventListener('click', closeEditModal);
+        document.addEventListener('keydown', function (e) {
+            if (e.key === 'Escape') closeEditModal();
+        });
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Internal state                                                       */
+    /* ------------------------------------------------------------------ */
+
+    let _gameIds            = [];
+    let _currentTags        = [];   // working copy for genres
+    let _originalTagsJSON   = null; // to detect changes
+    let _selectedLabel      = null; // working copy for playtime_label
+    let _originalLabel      = null; // to detect changes
+    let _autocompleteHi     = -1;   // highlighted index in dropdown
+
+    /* ------------------------------------------------------------------ */
+    /* Public entry point                                                   */
+    /* ------------------------------------------------------------------ */
+
+    window.openEditModal = async function (gameIds, currentData = {}) {
+        injectStyles();
+        ensureModalDOM();
+
+        // Normalise gameIds
+        _gameIds = Array.isArray(gameIds) ? gameIds : [gameIds];
+
+        // Resolve initial genres: use override if present, else store genres
+        const overrideRaw = currentData.genres_override;
+        const storeRaw    = currentData.genres;
+        const hasOverride = Array.isArray(overrideRaw) && overrideRaw.length > 0;
+        _currentTags      = hasOverride
+            ? [...overrideRaw]
+            : (Array.isArray(storeRaw) ? [...storeRaw] : []);
+        // For multi-game selection where data differs, we start fresh
+        if (_gameIds.length > 1 && currentData._mixed_genres) {
+            _currentTags = [];
+        }
+        _originalTagsJSON = JSON.stringify(_currentTags);
+
+        // Resolve initial playtime label
+        _selectedLabel  = currentData.playtime_label || null;
+        _originalLabel  = _selectedLabel;
+
+        // Update title
+        const n = _gameIds.length;
+        document.getElementById('em-title').textContent =
+            `Edit Metadata\u2002\u2013\u2002${n} game${n !== 1 ? 's' : ''}`;
+
+        // Render tag area
+        renderTags();
+
+        // Genres hint
+        const hint = document.getElementById('em-genres-hint');
+        if (_gameIds.length === 1) {
+            hint.textContent = hasOverride
+                ? 'Custom genres (overrides store data).'
+                : 'Currently showing store genres. Edit to create an override.';
+        } else {
+            hint.textContent = 'Editing will override store genres for all selected games.';
+        }
+
+        // Render playtime buttons
+        renderPlaytimeButtons();
+
+        // Show store playtime if single game
+        const storePt = document.getElementById('em-store-playtime');
+        if (_gameIds.length === 1 && currentData.playtime_hours) {
+            storePt.textContent = `Store value: ${parseFloat(currentData.playtime_hours).toFixed(1)} h`;
+        } else {
+            storePt.textContent = '';
+        }
+
+        // Wire up tag input
+        const tagInput = document.getElementById('em-tag-input');
+        tagInput.value = '';
+        tagInput.oninput  = onTagInput;
+        tagInput.onkeydown = onTagKeydown;
+        tagInput.onblur   = () => setTimeout(hideAutocomplete, 150);
+
+        // Wire up save
+        document.getElementById('em-save-btn').onclick = onSave;
+
+        // Reset status
+        setStatus('', '');
+
+        // Fetch genres for autocomplete (once)
+        if (!cachedGenres) {
+            cachedGenres = await fetch('/api/genres').then(r => r.json()).catch(() => []);
+        }
+
+        // Show overlay
+        const overlay = document.getElementById('edit-modal-overlay');
+        overlay.classList.add('active');
+        document.body.style.overflow = 'hidden';
+        tagInput.focus();
+    };
+
+    function closeEditModal() {
+        const overlay = document.getElementById('edit-modal-overlay');
+        if (!overlay) return;
+        overlay.classList.remove('active');
+        document.body.style.overflow = '';
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Tags                                                                 */
+    /* ------------------------------------------------------------------ */
+
+    function renderTags() {
+        const area = document.getElementById('em-tag-area');
+        // Remove existing tag chips, keep the input and autocomplete
+        area.querySelectorAll('.em-tag').forEach(el => el.remove());
+        const input = document.getElementById('em-tag-input');
+
+        _currentTags.forEach((tag, index) => {
+            const chip = document.createElement('span');
+            chip.className = 'em-tag';
+            chip.textContent = tag;
+            const btn = document.createElement('button');
+            btn.className = 'em-tag-remove';
+            btn.textContent = '\u00d7';
+            btn.title = 'Remove';
+            btn.onclick = () => { _currentTags.splice(index, 1); renderTags(); };
+            chip.appendChild(btn);
+            area.insertBefore(chip, input);
+        });
+    }
+
+    function addTag(raw) {
+        const tag = raw.trim();
+        if (!tag) return;
+        if (_currentTags.some(t => t.toLowerCase() === tag.toLowerCase())) return;
+        _currentTags.push(tag);
+        renderTags();
+        document.getElementById('em-tag-input').value = '';
+        hideAutocomplete();
+    }
+
+    function onTagInput(e) {
+        const val = e.target.value;
+        // Auto-add on comma
+        if (val.endsWith(',')) {
+            addTag(val.slice(0, -1));
+            return;
+        }
+        showAutocomplete(val.trim());
+    }
+
+    function onTagKeydown(e) {
+        const dropdown = document.getElementById('em-autocomplete');
+        const items = dropdown.querySelectorAll('.em-autocomplete-item');
+
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            if (_autocompleteHi >= 0 && items[_autocompleteHi]) {
+                addTag(items[_autocompleteHi].dataset.value);
+            } else {
+                addTag(e.target.value);
+            }
+        } else if (e.key === 'ArrowDown') {
+            e.preventDefault();
+            _autocompleteHi = Math.min(_autocompleteHi + 1, items.length - 1);
+            highlightAutocomplete(items);
+        } else if (e.key === 'ArrowUp') {
+            e.preventDefault();
+            _autocompleteHi = Math.max(_autocompleteHi - 1, -1);
+            highlightAutocomplete(items);
+        } else if (e.key === 'Backspace' && e.target.value === '' && _currentTags.length > 0) {
+            _currentTags.pop();
+            renderTags();
+        }
+    }
+
+    function showAutocomplete(query) {
+        const dropdown = document.getElementById('em-autocomplete');
+        if (!cachedGenres || !query) { hideAutocomplete(); return; }
+
+        const q = query.toLowerCase();
+        const matches = cachedGenres
+            .filter(g => g.toLowerCase().includes(q) &&
+                         !_currentTags.some(t => t.toLowerCase() === g.toLowerCase()))
+            .slice(0, 8);
+
+        if (!matches.length) { hideAutocomplete(); return; }
+
+        dropdown.innerHTML = matches
+            .map(g => `<div class="em-autocomplete-item" data-value="${escHtml(g)}">${escHtml(g)}</div>`)
+            .join('');
+
+        dropdown.querySelectorAll('.em-autocomplete-item').forEach(item => {
+            item.addEventListener('mousedown', () => addTag(item.dataset.value));
+        });
+
+        _autocompleteHi = -1;
+        dropdown.classList.add('active');
+    }
+
+    function hideAutocomplete() {
+        const dropdown = document.getElementById('em-autocomplete');
+        if (dropdown) { dropdown.classList.remove('active'); _autocompleteHi = -1; }
+    }
+
+    function highlightAutocomplete(items) {
+        items.forEach((el, i) => {
+            el.classList.toggle('highlighted', i === _autocompleteHi);
+        });
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Playtime                                                             */
+    /* ------------------------------------------------------------------ */
+
+    function renderPlaytimeButtons() {
+        const grid = document.getElementById('em-playtime-grid');
+        grid.innerHTML = '';
+
+        PLAYTIME_LABELS.forEach(label => {
+            const c = PLAYTIME_COLORS[label];
+            const btn = document.createElement('button');
+            btn.className = 'em-playtime-btn' + (label === _selectedLabel ? ' active' : '');
+            btn.textContent = PLAYTIME_DISPLAY[label] || label;
+            btn.style.background   = label === _selectedLabel ? c.bg : 'rgba(255,255,255,0.05)';
+            btn.style.borderColor  = label === _selectedLabel ? c.border : 'rgba(255,255,255,0.1)';
+            btn.style.color        = label === _selectedLabel ? c.text : '#888';
+            btn.onclick = () => {
+                _selectedLabel = (_selectedLabel === label) ? null : label;
+                renderPlaytimeButtons();
+            };
+            grid.appendChild(btn);
+        });
+
+        // Clear button (only shown when something is set)
+        if (_selectedLabel) {
+            const clearBtn = document.createElement('button');
+            clearBtn.className = 'em-playtime-btn em-playtime-clear';
+            clearBtn.textContent = 'Clear';
+            clearBtn.onclick = () => { _selectedLabel = null; renderPlaytimeButtons(); };
+            grid.appendChild(clearBtn);
+        }
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Status                                                               */
+    /* ------------------------------------------------------------------ */
+
+    function setStatus(msg, type) {
+        const el = document.getElementById('em-status');
+        if (!el) return;
+        el.textContent = msg;
+        el.className = 'em-status' + (type ? ' ' + type : '');
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Save                                                                 */
+    /* ------------------------------------------------------------------ */
+
+    async function onSave() {
+        const tagsChanged   = JSON.stringify(_currentTags) !== _originalTagsJSON;
+        const labelChanged  = _selectedLabel !== _originalLabel;
+
+        if (!tagsChanged && !labelChanged) {
+            closeEditModal();
+            return;
+        }
+
+        const saveBtn = document.getElementById('em-save-btn');
+        saveBtn.disabled = true;
+        saveBtn.textContent = 'Saving…';
+        setStatus('', '');
+
+        const body = { game_ids: _gameIds };
+
+        if (tagsChanged) {
+            body.genres_override = _currentTags.length > 0 ? _currentTags : null;
+            body.update_genres_override = true;
+        }
+        if (labelChanged) {
+            body.playtime_label = _selectedLabel;
+            body.update_playtime_label = true;
+        }
+
+        try {
+            const resp = await fetch('/api/games/bulk/edit', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(body),
+            });
+            const data = await resp.json();
+            if (data.success) {
+                setStatus(`Saved! (${data.updated} game${data.updated !== 1 ? 's' : ''} updated)`, 'success');
+                // Close after a short delay so the user sees the confirmation
+                setTimeout(() => {
+                    closeEditModal();
+                    // Notify host page if it wants to refresh data
+                    document.dispatchEvent(new CustomEvent('editModalSaved', {
+                        detail: { gameIds: _gameIds, body }
+                    }));
+                }, 800);
+            } else {
+                setStatus(data.detail || 'Save failed', 'error');
+                saveBtn.disabled = false;
+                saveBtn.textContent = 'Save';
+            }
+        } catch (err) {
+            setStatus('Network error: ' + err.message, 'error');
+            saveBtn.disabled = false;
+            saveBtn.textContent = 'Save';
+        }
+    }
+
+    /* ------------------------------------------------------------------ */
+    /* Helpers                                                              */
+    /* ------------------------------------------------------------------ */
+
+    function escHtml(str) {
+        return String(str)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;');
+    }
+
+})();

--- a/web/static/sw.js
+++ b/web/static/sw.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'backlogia-v1';
+const CACHE_NAME = 'backlogia-v2';
 const STATIC_ASSETS = [
   '/static/favicons/favicon.ico',
   '/static/favicons/favicon-32x32.png',

--- a/web/templates/game_detail.html
+++ b/web/templates/game_detail.html
@@ -1216,8 +1216,29 @@
                         {% endfor %}
                     </div>
                     {% set total_playtime = store_info|selectattr('playtime_hours')|map(attribute='playtime_hours')|sum %}
+                    {% if game.playtime_label %}
                     {% if total_playtime %}
-                    <span class="meta-item">{{ total_playtime|round(1) }} hours played</span>
+                    <span class="meta-item" style="color:#888;">{{ total_playtime|round(1) }}h</span>
+                    {% endif %}
+                    <span class="meta-item" style="text-transform:capitalize;color:
+                        {%- if game.playtime_label == 'heavily_played' %}#9c27b0
+                        {%- elif game.playtime_label == 'played' %}#4caf50
+                        {%- elif game.playtime_label == 'tried' %}#2196f3
+                        {%- elif game.playtime_label == 'abandoned' %}#f44336
+                        {%- else %}#888
+                        {%- endif %};">{{ game.playtime_label | replace('_', ' ') | capitalize }}</span>
+                    {% elif total_playtime is defined %}
+                    {% if total_playtime == 0 %}
+                    {% set derived_label = 'Not played' %}{% set derived_color = '#888' %}
+                    {% elif total_playtime <= 2 %}
+                    {% set derived_label = 'Just tried' %}{% set derived_color = '#2196f3' %}
+                    {% elif total_playtime <= 20 %}
+                    {% set derived_label = 'Played' %}{% set derived_color = '#4caf50' %}
+                    {% else %}
+                    {% set derived_label = 'Heavily played' %}{% set derived_color = '#9c27b0' %}
+                    {% endif %}
+                    <span class="meta-item" style="color:#888;" title="{{ total_playtime|round(1) }}h played">{{ total_playtime|round(1) }}h</span>
+                    <span class="meta-item" style="color:{{ derived_color }};" title="Derived from playtime">{{ derived_label }}</span>
                     {% endif %}
                     <button class="add-to-collection-btn" onclick="openCollectionModal()">
                         + Add to Collection
@@ -1238,10 +1259,16 @@
                 </div>
                 {% endif %}
 
-                {% set genres = parse_json(game.genres) %}
+                {% set genres_override = parse_json(game.genres_override) %}
+                {% set genres_raw = parse_json(game.genres) %}
+                {% set genres = genres_override if genres_override else genres_raw %}
                 {% if genres %}
                 <div class="section">
-                    <h2>Genres</h2>
+                    <h2>Genres
+                        {% if genres_override %}
+                        <small style="font-size:0.7rem;font-weight:400;color:#667eea;margin-left:6px;vertical-align:middle;">custom</small>
+                        {% endif %}
+                    </h2>
                     <div class="tags">
                         {% for genre in genres %}
                         <span class="tag">{{ genre }}</span>
@@ -1648,6 +1675,24 @@
                                         Sync with IGDB first to get Steam ID, or search on <a href="https://www.protondb.com/search?q={{ game.name|urlencode }}" target="_blank" rel="noopener">protondb.com</a>.
                                         {% endif %}
                                     </p>
+                                </div>
+                            </div>
+
+                            <div class="settings-section">
+                                <h3>Edit Metadata</h3>
+                                <div class="igdb-settings">
+                                    <p class="igdb-help" style="margin-bottom:12px;">
+                                        Override genres and set a personal playtime label for this game.
+                                    </p>
+                                    <button type="button" class="igdb-btn" onclick="openGameEditModal()" id="edit-metadata-btn">
+                                        Edit Metadata&hellip;
+                                    </button>
+                                    {% if game.genres_override or game.playtime_label %}
+                                    <div style="margin-top:10px;font-size:0.8rem;color:#667eea;">
+                                        {% if game.genres_override %}Custom genres active.{% endif %}
+                                        {% if game.playtime_label %}Label: <strong>{{ game.playtime_label }}</strong>.{% endif %}
+                                    </div>
+                                    {% endif %}
                                 </div>
                             </div>
 
@@ -2382,6 +2427,34 @@
             <div id="collection-status" class="collection-status" style="display: none;"></div>
         </div>
     </div>
+
+    <script src="/static/js/edit_modal.js"></script>
+    <script>
+        function openGameEditModal() {
+            // Parse template data for initial state
+            // game.genres and game.genres_override are JSON arrays stored as strings in the DB
+            const genresOverrideStr = {{ game.genres_override|tojson }};
+            const genresRawStr      = {{ game.genres|tojson }};
+            const playtimeLabel     = {{ game.playtime_label|tojson }};
+            {% set total_pt = store_info|selectattr('playtime_hours')|map(attribute='playtime_hours')|sum %}
+            const playtimeHours     = {{ total_pt or 'null' }};
+
+            openEditModal(
+                [gameId],
+                {
+                    genres_override: genresOverrideStr ? JSON.parse(genresOverrideStr) : null,
+                    genres:          genresRawStr      ? JSON.parse(genresRawStr)      : null,
+                    playtime_label:  playtimeLabel,
+                    playtime_hours:  playtimeHours,
+                }
+            );
+        }
+
+        // After save: reload the page to reflect updated metadata
+        document.addEventListener('editModalSaved', function () {
+            window.location.reload();
+        });
+    </script>
     {% include '_footer.html' %}
 </body>
 </html>

--- a/web/templates/game_detail.html
+++ b/web/templates/game_detail.html
@@ -111,6 +111,27 @@
             box-shadow: 0 5px 20px rgba(102, 126, 234, 0.4);
         }
 
+        .edit-metadata-btn {
+            padding: 10px 20px;
+            background: rgba(255,255,255,0.06);
+            border: 1px solid rgba(255,255,255,0.15);
+            border-radius: 8px;
+            color: #aaa;
+            font-size: 0.9rem;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.2s;
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .edit-metadata-btn:hover {
+            background: rgba(255,255,255,0.1);
+            color: #e4e4e4;
+            border-color: rgba(255,255,255,0.3);
+        }
+
         /* Collection Modal */
         .collection-modal-overlay {
             display: none;
@@ -1242,6 +1263,9 @@
                     {% endif %}
                     <button class="add-to-collection-btn" onclick="openCollectionModal()">
                         + Add to Collection
+                    </button>
+                    <button class="edit-metadata-btn" onclick="openGameEditModal()">
+                        &#9998; Edit Metadata
                     </button>
                 </div>
             </div>

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -281,6 +281,22 @@
             gap: 20px;
         }
 
+        .filter-col-left,
+        .filter-col-right {
+            display: flex;
+            flex-direction: column;
+            gap: 20px;
+        }
+
+        .filter-toggles-row {
+            display: flex;
+            gap: 20px;
+        }
+
+        .filter-toggles-row .filter-section {
+            flex: 1;
+        }
+
         .filter-section {
             display: flex;
             flex-direction: column;
@@ -347,6 +363,11 @@
             display: flex;
             flex-direction: column;
             gap: 2px;
+        }
+
+        /* Tags list in the right column gets more room */
+        .filter-col-right > .filter-section > .filter-tags-container {
+            max-height: 440px;
         }
 
         .filter-tag-search {
@@ -423,6 +444,13 @@
         .filter-tag-option.hidden {
             display: none;
         }
+
+        /* Playtime filter chip color accents */
+        .filter-pt-unplayed input:checked ~ .tag-label { color: #aaa; }
+        .filter-pt-tried input:checked ~ .tag-label { color: #2196f3; }
+        .filter-pt-played input:checked ~ .tag-label { color: #4caf50; }
+        .filter-pt-heavily-played input:checked ~ .tag-label { color: #9c27b0; }
+        .filter-pt-abandoned input:checked ~ .tag-label { color: #f44336; }
 
         /* Toggle Switch */
         .toggle-switch {
@@ -560,6 +588,9 @@
         @media (max-width: 768px) {
             .filter-panel-grid {
                 grid-template-columns: 1fr;
+            }
+            .filter-col-right {
+                margin-top: 0;
             }
         }
 
@@ -1031,6 +1062,50 @@
             background: rgba(102, 126, 234, 0.3);
         }
 
+        .action-btn.edit {
+            background: rgba(255, 193, 7, 0.15);
+            color: #ffc107;
+            border: 1px solid rgba(255, 193, 7, 0.3);
+        }
+
+        .action-btn.edit:hover {
+            background: rgba(255, 193, 7, 0.25);
+        }
+
+        /* Per-card pencil edit button */
+        .card-edit-btn {
+            position: absolute;
+            top: 10px;
+            right: 10px;
+            background: rgba(0, 0, 0, 0.7);
+            border: 1px solid rgba(255, 255, 255, 0.3);
+            border-radius: 6px;
+            color: #e4e4e4;
+            font-size: 0.85rem;
+            width: 28px;
+            height: 28px;
+            cursor: pointer;
+            display: none;
+            align-items: center;
+            justify-content: center;
+            z-index: 10;
+            transition: background 0.2s, border-color 0.2s;
+            padding: 0;
+        }
+
+        .card-edit-btn:hover {
+            background: rgba(255, 193, 7, 0.3);
+            border-color: rgba(255, 193, 7, 0.6);
+        }
+
+        /* Show pencil only on pointer devices that support hover */
+        @media (hover: hover) {
+            .game-card:hover .card-edit-btn { display: flex; }
+        }
+
+        /* Never show in select mode */
+        .select-mode .card-edit-btn { display: none !important; }
+
         /* Collection Modal */
         .collection-modal-overlay {
             display: none;
@@ -1338,6 +1413,7 @@
         {% if current_collection %}{% if active_filter_count.append(1) %}{% endif %}{% endif %}
         {% if current_protondb_tier %}{% if active_filter_count.append(1) %}{% endif %}{% endif %}
         {% if current_no_igdb %}{% if active_filter_count.append(1) %}{% endif %}{% endif %}
+        {% if current_playtime_labels %}{% if active_filter_count.append(1) %}{% endif %}{% endif %}
 
         <div class="filters">
             <button class="filter-toggle-btn {% if active_filter_count %}active{% endif %}" onclick="toggleFilterPanel()" id="filter-toggle" title="Filters">
@@ -1357,6 +1433,7 @@
                     {% if current_collection %}<input type="hidden" name="collection" value="{{ current_collection }}">{% endif %}
                     {% if current_protondb_tier %}<input type="hidden" name="protondb_tier" value="{{ current_protondb_tier }}">{% endif %}
                     {% if current_no_igdb %}<input type="hidden" name="no_igdb" value="true">{% endif %}
+                    {% for lbl in current_playtime_labels %}<input type="hidden" name="playtime_label" value="{{ lbl }}">{% endfor %}
                     <input type="text" name="search" placeholder="Search games..." value="{{ current_search }}">
                 </form>
             </div>
@@ -1378,7 +1455,7 @@
                 <option value="playtime_hours-desc" {% if current_sort == 'playtime_hours' %}selected{% endif %}>Most Played</option>
             </select>
 
-            {% set has_any_filter = current_stores or current_genres or current_search or current_exclude_streaming or current_collection or current_protondb_tier or current_no_igdb or (current_sort != 'name') or (current_sort == 'name' and current_order != 'asc') %}
+            {% set has_any_filter = current_stores or current_genres or current_search or current_exclude_streaming or current_collection or current_protondb_tier or current_no_igdb or current_playtime_labels or (current_sort != 'name') or (current_sort == 'name' and current_order != 'asc') %}
             {% if has_any_filter %}
             <button class="reset-filters-btn" onclick="resetAllFilters()" title="Reset all filters">
                 &#10005;
@@ -1393,81 +1470,126 @@
         <!-- Filter Panel -->
         <div class="filter-panel" id="filter-panel">
             <div class="filter-panel-grid">
-                <!-- Stores -->
-                <div class="filter-section">
-                    <div class="filter-section-title">Stores</div>
-                    <div class="filter-store-list" id="filter-stores">
-                        {% for store, count in store_counts.items() %}
-                        <label class="filter-store-chip {% if store in current_stores %}selected{% endif %}">
-                            <input type="checkbox" name="panel-stores" value="{{ store }}" {% if store in current_stores %}checked{% endif %}>
-                            {% if store in store_icons %}
-                            <img src="/static/images/{{ store_icons[store] }}" alt="{{ store }}">
-                            {% endif %}
-                            <span>{{ store|capitalize }}</span>
-                            <span class="chip-count">{{ count }}</span>
-                        </label>
-                        {% endfor %}
+
+                <!-- Left column: Stores + Playtime + Collection + ProtonDB -->
+                <div class="filter-col-left">
+
+                    <!-- Stores -->
+                    <div class="filter-section">
+                        <div class="filter-section-title">Stores</div>
+                        <div class="filter-store-list" id="filter-stores">
+                            {% for store, count in store_counts.items() %}
+                            <label class="filter-store-chip {% if store in current_stores %}selected{% endif %}">
+                                <input type="checkbox" name="panel-stores" value="{{ store }}" {% if store in current_stores %}checked{% endif %}>
+                                {% if store in store_icons %}
+                                <img src="/static/images/{{ store_icons[store] }}" alt="{{ store }}">
+                                {% endif %}
+                                <span>{{ store|capitalize }}</span>
+                                <span class="chip-count">{{ count }}</span>
+                            </label>
+                            {% endfor %}
+                        </div>
                     </div>
-                </div>
 
-                <!-- Tags -->
-                {% if genre_counts %}
-                <div class="filter-section">
-                    <div class="filter-section-title">Tags</div>
-                    <input type="text" class="filter-tag-search" placeholder="Search tags..." id="panel-tag-search" oninput="filterPanelTags()">
-                    <div class="filter-tags-container" id="filter-tags">
-                        {% for genre, count in genre_counts.items() %}
-                        <label class="filter-tag-option">
-                            <input type="checkbox" name="panel-genres" value="{{ genre }}" {% if genre in current_genres %}checked{% endif %}>
-                            <span class="tag-checkbox"></span>
-                            <span class="tag-label">{{ genre }}</span>
-                            <span class="tag-count">{{ count }}</span>
-                        </label>
-                        {% endfor %}
+                    <!-- Playtime -->
+                    <div class="filter-section">
+                        <div class="filter-section-title">Playtime</div>
+                        <div class="filter-tags-container" id="filter-playtime">
+                            <label class="filter-tag-option filter-pt-unplayed">
+                                <input type="checkbox" value="unplayed" {% if 'unplayed' in current_playtime_labels %}checked{% endif %}>
+                                <span class="tag-checkbox"></span>
+                                <span class="tag-label">Not played</span>
+                            </label>
+                            <label class="filter-tag-option filter-pt-tried">
+                                <input type="checkbox" value="tried" {% if 'tried' in current_playtime_labels %}checked{% endif %}>
+                                <span class="tag-checkbox"></span>
+                                <span class="tag-label">Just tried</span>
+                                <span class="tag-count">&le;&thinsp;2h</span>
+                            </label>
+                            <label class="filter-tag-option filter-pt-played">
+                                <input type="checkbox" value="played" {% if 'played' in current_playtime_labels %}checked{% endif %}>
+                                <span class="tag-checkbox"></span>
+                                <span class="tag-label">Played</span>
+                            </label>
+                            <label class="filter-tag-option filter-pt-heavily-played">
+                                <input type="checkbox" value="heavily_played" {% if 'heavily_played' in current_playtime_labels %}checked{% endif %}>
+                                <span class="tag-checkbox"></span>
+                                <span class="tag-label">Heavily played</span>
+                            </label>
+                            <label class="filter-tag-option filter-pt-abandoned">
+                                <input type="checkbox" value="abandoned" {% if 'abandoned' in current_playtime_labels %}checked{% endif %}>
+                                <span class="tag-checkbox"></span>
+                                <span class="tag-label">Abandoned</span>
+                            </label>
+                        </div>
                     </div>
-                </div>
-                {% endif %}
 
-                <!-- Exclude Streaming -->
-                <div class="filter-section">
-                    <div class="filter-section-title">Streaming</div>
-                    <div class="toggle-switch {% if current_exclude_streaming %}active{% endif %}" id="toggle-exclude-streaming" onclick="toggleSwitch(this)">
-                        <div class="toggle-track"><div class="toggle-thumb"></div></div>
-                        <span class="toggle-label">Exclude streaming-only games</span>
+                    <!-- Collection -->
+                    <div class="filter-section">
+                        <div class="filter-section-title">Collection</div>
+                        <select class="filter-select" id="filter-collection">
+                            <option value="0">All Games</option>
+                            {% for col in collections %}
+                            <option value="{{ col.id }}" {% if current_collection == col.id %}selected{% endif %}>{{ col.name }} ({{ col.game_count }})</option>
+                            {% endfor %}
+                        </select>
                     </div>
-                </div>
 
-                <!-- Collection -->
-                <div class="filter-section">
-                    <div class="filter-section-title">Collection</div>
-                    <select class="filter-select" id="filter-collection">
-                        <option value="0">All Games</option>
-                        {% for col in collections %}
-                        <option value="{{ col.id }}" {% if current_collection == col.id %}selected{% endif %}>{{ col.name }} ({{ col.game_count }})</option>
-                        {% endfor %}
-                    </select>
-                </div>
-
-                <!-- ProtonDB Tier -->
-                <div class="filter-section">
-                    <div class="filter-section-title">ProtonDB Tier</div>
-                    <select class="filter-select" id="filter-protondb">
-                        <option value="">Any</option>
-                        <option value="platinum" {% if current_protondb_tier == 'platinum' %}selected{% endif %}>Platinum</option>
-                        <option value="gold" {% if current_protondb_tier == 'gold' %}selected{% endif %}>Gold or higher</option>
-                        <option value="silver" {% if current_protondb_tier == 'silver' %}selected{% endif %}>Silver or higher</option>
-                        <option value="bronze" {% if current_protondb_tier == 'bronze' %}selected{% endif %}>Bronze or higher</option>
-                    </select>
-                </div>
-
-                <!-- No IGDB Data -->
-                <div class="filter-section">
-                    <div class="filter-section-title">IGDB Match</div>
-                    <div class="toggle-switch {% if current_no_igdb %}active{% endif %}" id="toggle-no-igdb" onclick="toggleSwitch(this)">
-                        <div class="toggle-track"><div class="toggle-thumb"></div></div>
-                        <span class="toggle-label">Show only games without IGDB data</span>
+                    <!-- ProtonDB Tier -->
+                    <div class="filter-section">
+                        <div class="filter-section-title">ProtonDB Tier</div>
+                        <select class="filter-select" id="filter-protondb">
+                            <option value="">Any</option>
+                            <option value="platinum" {% if current_protondb_tier == 'platinum' %}selected{% endif %}>Platinum</option>
+                            <option value="gold" {% if current_protondb_tier == 'gold' %}selected{% endif %}>Gold or higher</option>
+                            <option value="silver" {% if current_protondb_tier == 'silver' %}selected{% endif %}>Silver or higher</option>
+                            <option value="bronze" {% if current_protondb_tier == 'bronze' %}selected{% endif %}>Bronze or higher</option>
+                        </select>
                     </div>
+
                 </div>
+
+                <!-- Right column: Tags + Streaming & IGDB -->
+                <div class="filter-col-right">
+
+                    <!-- Tags -->
+                    {% if genre_counts %}
+                    <div class="filter-section">
+                        <div class="filter-section-title">Tags</div>
+                        <input type="text" class="filter-tag-search" placeholder="Search tags..." id="panel-tag-search" oninput="filterPanelTags()">
+                        <div class="filter-tags-container" id="filter-tags">
+                            {% for genre, count in genre_counts.items() %}
+                            <label class="filter-tag-option">
+                                <input type="checkbox" name="panel-genres" value="{{ genre }}" {% if genre in current_genres %}checked{% endif %}>
+                                <span class="tag-checkbox"></span>
+                                <span class="tag-label">{{ genre }}</span>
+                                <span class="tag-count">{{ count }}</span>
+                            </label>
+                            {% endfor %}
+                        </div>
+                    </div>
+                    {% endif %}
+
+                    <!-- Streaming + IGDB on same row -->
+                    <div class="filter-toggles-row">
+                        <div class="filter-section">
+                            <div class="filter-section-title">Streaming</div>
+                            <div class="toggle-switch {% if current_exclude_streaming %}active{% endif %}" id="toggle-exclude-streaming" onclick="toggleSwitch(this)">
+                                <div class="toggle-track"><div class="toggle-thumb"></div></div>
+                                <span class="toggle-label">Exclude streaming-only</span>
+                            </div>
+                        </div>
+                        <div class="filter-section">
+                            <div class="filter-section-title">IGDB Match</div>
+                            <div class="toggle-switch {% if current_no_igdb %}active{% endif %}" id="toggle-no-igdb" onclick="toggleSwitch(this)">
+                                <div class="toggle-track"><div class="toggle-thumb"></div></div>
+                                <span class="toggle-label">Without IGDB data only</span>
+                            </div>
+                        </div>
+                    </div>
+
+                </div>
+
             </div>
 
             <div class="filter-panel-footer">
@@ -1493,6 +1615,7 @@
             {% set game = grouped_game.primary %}
             <a href="/game/{{ grouped_game.game_ids[0] }}" class="game-card" data-game-ids="{{ grouped_game.game_ids|join(',') }}">
                 <div class="game-checkbox" onclick="toggleGameSelection(event, this)"></div>
+                <button class="card-edit-btn" onclick="handleCardEditClick(event, this)" title="Edit metadata">✏</button>
                 {% set cover_url = game.cover_url_override or game.igdb_cover_url or game.cover_image %}
                 <div class="game-cover-wrapper">
                     {% if cover_url %}
@@ -1534,6 +1657,9 @@
                 <span class="select-all-link" onclick="selectAllGames()">Select All</span>
             </div>
             <div class="action-buttons">
+                <button class="action-btn edit" onclick="openBulkEditModal()">
+                    Edit Metadata
+                </button>
                 <button class="action-btn collection" onclick="openCollectionModal()">
                     Add to Collection
                 </button>
@@ -1626,12 +1752,13 @@
             const collection = parseInt(document.getElementById('filter-collection')?.value || '0');
             const protondbTier = document.getElementById('filter-protondb')?.value || '';
             const noIgdb = document.getElementById('toggle-no-igdb')?.classList.contains('active') || false;
-            return { stores, genres, excludeStreaming, collection, protondbTier, noIgdb };
+            const playtimeLabels = Array.from(document.querySelectorAll('#filter-playtime input:checked')).map(cb => cb.value);
+            return { stores, genres, excludeStreaming, collection, protondbTier, noIgdb, playtimeLabels };
         }
 
         // Save filter/sort preferences to localStorage
-        function saveFilterPreferences(stores, genres, search, sort, order, excludeStreaming, collection, protondbTier, noIgdb) {
-            const prefs = { stores, genres, search, sort, order, excludeStreaming: excludeStreaming || false, collection: collection || 0, protondbTier: protondbTier || '', noIgdb: noIgdb || false };
+        function saveFilterPreferences(stores, genres, search, sort, order, excludeStreaming, collection, protondbTier, noIgdb, playtimeLabels) {
+            const prefs = { stores, genres, search, sort, order, excludeStreaming: excludeStreaming || false, collection: collection || 0, protondbTier: protondbTier || '', noIgdb: noIgdb || false, playtimeLabels: playtimeLabels || [] };
             localStorage.setItem('filterPreferences', JSON.stringify(prefs));
         }
 
@@ -1641,7 +1768,8 @@
             const hasUrlParams = urlParams.has('stores') || urlParams.has('genres') ||
                                  urlParams.has('search') || urlParams.has('sort') || urlParams.has('order') ||
                                  urlParams.has('exclude_streaming') || urlParams.has('collection') ||
-                                 urlParams.has('protondb_tier') || urlParams.has('no_igdb');
+                                 urlParams.has('protondb_tier') || urlParams.has('no_igdb') ||
+                                 urlParams.has('playtime_label');
 
             if (hasUrlParams) {
                 const stores = urlParams.getAll('stores');
@@ -1653,7 +1781,8 @@
                 const collection = parseInt(urlParams.get('collection') || '0');
                 const protondbTier = urlParams.get('protondb_tier') || '';
                 const noIgdb = urlParams.get('no_igdb') === 'true';
-                saveFilterPreferences(stores, genres, search, sort, order, excludeStreaming, collection, protondbTier, noIgdb);
+                const playtimeLabels = urlParams.getAll('playtime_label');
+                saveFilterPreferences(stores, genres, search, sort, order, excludeStreaming, collection, protondbTier, noIgdb, playtimeLabels);
                 return;
             }
 
@@ -1662,8 +1791,8 @@
                 const prefs = JSON.parse(saved);
                 if ((prefs.stores && prefs.stores.length) || (prefs.genres && prefs.genres.length) ||
                     prefs.search || (prefs.sort && prefs.sort !== 'name') || (prefs.order && prefs.order !== 'asc') ||
-                    prefs.excludeStreaming || prefs.collection || prefs.protondbTier || prefs.noIgdb) {
-                    const url = buildUrl(prefs.stores || [], prefs.genres || [], prefs.search || '', prefs.sort || 'name', prefs.order || 'asc', prefs.excludeStreaming || false, prefs.collection || 0, prefs.protondbTier || '', prefs.noIgdb || false);
+                    prefs.excludeStreaming || prefs.collection || prefs.protondbTier || prefs.noIgdb || (prefs.playtimeLabels && prefs.playtimeLabels.length)) {
+                    const url = buildUrl(prefs.stores || [], prefs.genres || [], prefs.search || '', prefs.sort || 'name', prefs.order || 'asc', prefs.excludeStreaming || false, prefs.collection || 0, prefs.protondbTier || '', prefs.noIgdb || false, prefs.playtimeLabels || []);
                     window.location.href = url;
                 }
             }
@@ -1692,10 +1821,11 @@
             const collection = parseInt(form.querySelector('input[name="collection"]')?.value || '0');
             const protondbTier = form.querySelector('input[name="protondb_tier"]')?.value || '';
             const noIgdb = form.querySelector('input[name="no_igdb"]')?.value === 'true' || false;
-            saveFilterPreferences(stores, genres, search, sort, order, excludeStreaming, collection, protondbTier, noIgdb);
+            const playtimeLabels = Array.from(form.querySelectorAll('input[name="playtime_label"]')).map(i => i.value);
+            saveFilterPreferences(stores, genres, search, sort, order, excludeStreaming, collection, protondbTier, noIgdb, playtimeLabels);
         }
 
-        function buildUrl(stores, genres, search, sort, order, excludeStreaming, collection, protondbTier, noIgdb) {
+        function buildUrl(stores, genres, search, sort, order, excludeStreaming, collection, protondbTier, noIgdb, playtimeLabels) {
             const params = new URLSearchParams();
             stores.forEach(store => params.append('stores', store));
             genres.forEach(genre => params.append('genres', genre));
@@ -1706,6 +1836,7 @@
             if (collection) params.set('collection', collection);
             if (protondbTier) params.set('protondb_tier', protondbTier);
             if (noIgdb) params.set('no_igdb', 'true');
+            if (playtimeLabels && playtimeLabels.length) playtimeLabels.forEach(l => params.append('playtime_label', l));
             return '?' + params.toString();
         }
 
@@ -1744,8 +1875,8 @@
             const search = '{{ current_search }}';
             const sort = '{{ current_sort }}';
             const order = '{{ current_order }}';
-            saveFilterPreferences(state.stores, state.genres, search, sort, order, state.excludeStreaming, state.collection, state.protondbTier, state.noIgdb);
-            window.location.href = buildUrl(state.stores, state.genres, search, sort, order, state.excludeStreaming, state.collection, state.protondbTier, state.noIgdb);
+            saveFilterPreferences(state.stores, state.genres, search, sort, order, state.excludeStreaming, state.collection, state.protondbTier, state.noIgdb, state.playtimeLabels);
+            window.location.href = buildUrl(state.stores, state.genres, search, sort, order, state.excludeStreaming, state.collection, state.protondbTier, state.noIgdb, state.playtimeLabels);
         }
 
         function clearAllPanelFilters() {
@@ -1765,6 +1896,7 @@
             if (collectionSelect) collectionSelect.value = '0';
             const protondbSelect = document.getElementById('filter-protondb');
             if (protondbSelect) protondbSelect.value = '';
+            document.querySelectorAll('#filter-playtime input').forEach(cb => { cb.checked = false; });
             // Clear tag search
             const tagSearch = document.getElementById('panel-tag-search');
             if (tagSearch) { tagSearch.value = ''; filterPanelTags(); }
@@ -1786,8 +1918,9 @@
             const collection = {{ current_collection }};
             const protondbTier = '{{ current_protondb_tier }}';
             const noIgdb = {{ 'true' if current_no_igdb else 'false' }};
-            saveFilterPreferences(currentStores, genres, search, sort, order, excludeStreaming, collection, protondbTier, noIgdb);
-            window.location.href = buildUrl(currentStores, genres, search, sort, order, excludeStreaming, collection, protondbTier, noIgdb);
+            const playtimeLabels = [{% for lbl in current_playtime_labels %}'{{ lbl }}'{% if not loop.last %}, {% endif %}{% endfor %}];
+            saveFilterPreferences(currentStores, genres, search, sort, order, excludeStreaming, collection, protondbTier, noIgdb, playtimeLabels);
+            window.location.href = buildUrl(currentStores, genres, search, sort, order, excludeStreaming, collection, protondbTier, noIgdb, playtimeLabels);
         }
 
         function applySort(value) {
@@ -1799,7 +1932,8 @@
             const collection = {{ current_collection }};
             const protondbTier = '{{ current_protondb_tier }}';
             const noIgdb = {{ 'true' if current_no_igdb else 'false' }};
-            window.location.href = buildUrl(stores, genres, search, sort, order, excludeStreaming, collection, protondbTier, noIgdb);
+            const playtimeLabels = [{% for lbl in current_playtime_labels %}'{{ lbl }}'{% if not loop.last %}, {% endif %}{% endfor %}];
+            window.location.href = buildUrl(stores, genres, search, sort, order, excludeStreaming, collection, protondbTier, noIgdb, playtimeLabels);
         }
 
         // Multi-select functionality
@@ -2190,6 +2324,31 @@
                 const checkbox = card.querySelector('.game-checkbox');
                 toggleGameSelection(event, checkbox);
             }
+        });
+    </script>
+
+    <script src="/static/js/edit_modal.js"></script>
+    <script>
+        // Bulk edit from action bar (multi-select mode)
+        function openBulkEditModal() {
+            if (selectedGames.size === 0) return;
+            const gameIds = Array.from(selectedGames).map(id => parseInt(id));
+            // Mixed selection: don't pre-fill genres
+            openEditModal(gameIds, { _mixed_genres: gameIds.length > 1 });
+        }
+
+        // Per-card pencil button handler
+        function handleCardEditClick(event, btn) {
+            event.preventDefault();
+            event.stopPropagation();
+            const card = btn.closest('.game-card');
+            const gameIds = card.dataset.gameIds.split(',').map(id => parseInt(id));
+            openEditModal(gameIds, {});
+        }
+
+        // After save: reload the page to reflect updated metadata
+        document.addEventListener('editModalSaved', function () {
+            window.location.reload();
         });
     </script>
     {% include '_footer.html' %}

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1613,7 +1613,12 @@
         <div id="games-grid" class="games-grid size-medium">
             {% for grouped_game in games %}
             {% set game = grouped_game.primary %}
-            <a href="/game/{{ grouped_game.game_ids[0] }}" class="game-card" data-game-ids="{{ grouped_game.game_ids|join(',') }}">
+            <a href="/game/{{ grouped_game.game_ids[0] }}" class="game-card"
+               data-game-ids="{{ grouped_game.game_ids|join(',') }}"
+               data-genres-override="{{ game.genres_override or '' }}"
+               data-genres="{{ game.genres or '' }}"
+               data-playtime-label="{{ game.playtime_label or '' }}"
+               data-playtime-hours="{{ game.playtime_hours or '' }}">
                 <div class="game-checkbox" onclick="toggleGameSelection(event, this)"></div>
                 <button class="card-edit-btn" onclick="handleCardEditClick(event, this)" title="Edit metadata">✏</button>
                 {% set cover_url = game.cover_url_override or game.igdb_cover_url or game.cover_image %}
@@ -2333,8 +2338,14 @@
         function openBulkEditModal() {
             if (selectedGames.size === 0) return;
             const gameIds = Array.from(selectedGames).map(id => parseInt(id));
-            // Mixed selection: don't pre-fill genres
-            openEditModal(gameIds, { _mixed_genres: gameIds.length > 1 });
+            // Single card selected: pre-populate with its current metadata
+            const selectedCards = document.querySelectorAll('.game-card.selected');
+            if (selectedCards.length === 1) {
+                _openEditModalFromCard(selectedCards[0], gameIds);
+                return;
+            }
+            // Multiple cards: mixed selection, don't pre-fill
+            openEditModal(gameIds, { _mixed_genres: true });
         }
 
         // Per-card pencil button handler
@@ -2343,7 +2354,19 @@
             event.stopPropagation();
             const card = btn.closest('.game-card');
             const gameIds = card.dataset.gameIds.split(',').map(id => parseInt(id));
-            openEditModal(gameIds, {});
+            _openEditModalFromCard(card, gameIds);
+        }
+
+        // Helper: open edit modal pre-populated from a card's data attributes
+        function _openEditModalFromCard(card, gameIds) {
+            const genresOverrideRaw = card.dataset.genresOverride || '';
+            const genresRaw         = card.dataset.genres         || '';
+            openEditModal(gameIds, {
+                genres_override: genresOverrideRaw ? JSON.parse(genresOverrideRaw) : null,
+                genres:          genresRaw         ? JSON.parse(genresRaw)         : null,
+                playtime_label:  card.dataset.playtimeLabel  || null,
+                playtime_hours:  card.dataset.playtimeHours  ? parseFloat(card.dataset.playtimeHours) : null,
+            });
         }
 
         // After save: reload the page to reflect updated metadata

--- a/web/utils/filters.py
+++ b/web/utils/filters.py
@@ -12,3 +12,12 @@ EXCLUDE_HIDDEN_FILTER = EXCLUDE_DUPLICATES_FILTER + """
     AND (hidden IS NULL OR hidden = 0)
     AND (removed IS NULL OR removed = 0)
 """
+
+# Valid playtime label values (used by the edit API and the library filter)
+PLAYTIME_LABELS: frozenset[str] = frozenset({
+    "unplayed",
+    "tried",
+    "played",
+    "heavily_played",
+    "abandoned",
+})


### PR DESCRIPTION
## Overview

Two new features: bulk editing of game metadata directly from the library, and a playtime filter in the filter panel.

---

## Feature 1 — Playtime Filter

Games can now be filtered by playtime status in the library filter panel.

**How it works:**
- Five labels: `Not played`, `Just tried` (≤ 2h), `Played` (2–20h), `Heavily played` (> 20h), `Abandoned`
- Multi-select checkboxes (same UI as the Tags filter)
- Filters match either an **explicit label** set on the game, or a **derived label** computed from the numeric `playtime_hours` value provided by stores (Steam, etc.)
- Explicit label always takes priority over the derived one

**Display:**
- Game detail page shows the derived label (with color) when no explicit label is set but `playtime_hours` is available

**Internal label value:** `heavily_played` (replaces the previously planned `completed` which was ambiguous)

---

## Feature 2 — Bulk Metadata Editing

Games can have two metadata fields overridden directly from the UI, without re-syncing from stores.

**Editable fields:**
- **Genres override** — replaces the store-provided genres with a custom list; tag input with autocomplete from existing genres
- **Playtime label** — assigns an explicit playtime label to the game

**Persistence across syncs:**
- `genres_override` and `playtime_label` are **never overwritten by store syncs or IGDB sync** — they are write-only from the edit API
- The genre filter and Tags panel both use `COALESCE(genres_override, genres)`, so overrides take effect everywhere immediately
- Resetting an override to empty restores the original store/IGDB value

**Entry points:**
- **Library view** — pencil icon (✏) on each game card; multi-select action bar button "Edit Metadata" for bulk editing
- **Game detail page** — "Edit Metadata" button next to "+ Add to Collection" in the hero, and also in the Settings section

**API:**
- `GET /api/genres` — returns all known genres (merged from `genres` and `genres_override` columns)
- `POST /api/games/bulk/edit` — updates `genres_override` and/or `playtime_label` for one or more games; each field is opt-in via `update_genres_override` / `update_playtime_label` flags to avoid accidental overwrites

---

## Filter Panel Reorganisation

The filter panel layout was restructured into two explicit columns to better use available space:

| Left column | Right column |
|---|---|
| Stores | Tags (scrollable, taller) |
| Playtime | Streaming / IGDB Match (side by side) |
| Collection | |
| ProtonDB Tier | |

---

## Edit Modal — Auto-suggested Playtime Label

When opening the edit modal on a game that has no explicit playtime label set, the UI now visually suggests the label that would be auto-derived from the store's `playtime_hours` value:

- The matching button is rendered with a dashed border, italic text, and 75% opacity
- A `· auto` suffix is appended to its label to distinguish it from a confirmed selection
- Clicking the button confirms the suggestion and removes the "auto" style
- Clicking "Clear" restores the suggestion if hours are available
- The hours hint line also shows: `Store value: X.Xh → "Heavily played" suggested`

This helps users understand what the current effective label is before they override it.

---

## Playtime Sort Fix

The "Most Played" sort now correctly accounts for games that have a manual `playtime_label` but no numeric `playtime_hours` (e.g. GOG/local games where only the label was set manually).

**Before:** games with `playtime_hours = NULL` always sorted to the bottom regardless of their label.

**After:** sort uses `COALESCE(playtime_hours, sentinel_from_label)` with these sentinel values:

| Label | Sentinel |
|---|---|
| `heavily_played` | 1000 |
| `abandoned` | 50 |
| `played` | 11 |
| `tried` | 1 |
| `unplayed` | 0 |
| *(no label)* | NULL → bottom |

Both the SQL `ORDER BY` clause and the Python post-grouping sort (used when IGDB grouping is active) apply the same logic.

---

## Edit Modal Pre-population Fix (Library View)

When opening the edit modal from the library (pencil icon on a card, or action bar with a single card selected), the modal now pre-populates the current `genres_override`, `genres`, `playtime_label`, and `playtime_hours` values — identical behaviour to the game detail page.

**Before:** card edit always opened with an empty form (no current data shown).  
**After:** the card element carries the game's metadata as `data-*` attributes; `handleCardEditClick` reads them and passes a fully populated `currentData` object to `openEditModal()`. When the action bar "Edit Metadata" is used with exactly one card selected, the same pre-population applies; multi-card selection still opens the mixed/empty form.

---

## Technical Notes

- New DB columns: `genres_override TEXT`, `playtime_label TEXT` (added via `ensure_edit_overrides()` migration, non-destructive)
- New file: `web/static/js/edit_modal.js` — self-contained modal (overlay on desktop, bottom sheet on mobile)
- Service worker cache version bumped to `backlogia-v2` to avoid serving stale JS
- 15 tests in `tests/test_game_edit.py` covering both API endpoints — all passing

## Screenshots

### New filter panel

<img width="1712" height="1032" alt="image" src="https://github.com/user-attachments/assets/df8fbd10-184e-4402-b26b-c6c958386a42" />

### Edit metadata

#### One game at a time - in library

<img width="376" height="490" alt="image" src="https://github.com/user-attachments/assets/94affd81-2c55-4382-a3c0-0d7789723aba" />
#### Edit one game - in library

<img width="630" height="553" alt="image" src="https://github.com/user-attachments/assets/794256c6-b0d6-4be5-9acf-fe6f7682ec51" />

#### Select multiple games

<img width="1132" height="445" alt="image" src="https://github.com/user-attachments/assets/25c0f270-c9b6-44a3-9993-3ad1963fe8a8" />

#### Edit multiple games

<img width="635" height="534" alt="image" src="https://github.com/user-attachments/assets/6d6feca7-779b-4e6f-9ea3-9a84ef205da3" />

#### Edit one game - in game details

<img width="1022" height="456" alt="image" src="https://github.com/user-attachments/assets/ce97a82e-c295-4710-81f8-548934dbce40" />

#### Edit one game - dialog

<img width="1551" height="881" alt="image" src="https://github.com/user-attachments/assets/0debe0b5-69a4-46de-898f-983e47a4a730" />
