### PR TITLE
bugfix - Search feature not finding special characters like '%'

### DIFF
--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,0 +1,104 @@
+"""tests/test_search.py
+
+Tests for the search functionality, focusing on correct escaping of SQL LIKE
+special characters (%, _, \\) in search queries.
+"""
+
+import pytest
+
+from web.utils.helpers import escape_like
+
+
+# --------------------------------------------------------------------------- #
+# escape_like helper                                                            #
+# --------------------------------------------------------------------------- #
+
+
+class TestEscapeLike:
+    def test_plain_string_unchanged(self):
+        """Strings with no special characters are left as-is."""
+        assert escape_like("hello world") == "hello world"
+
+    def test_percent_escaped(self):
+        """% is escaped to \\%."""
+        assert escape_like("%") == "\\%"
+        assert escape_like("100%") == "100\\%"
+        assert escape_like("%complete%") == "\\%complete\\%"
+
+    def test_underscore_escaped(self):
+        """_ is escaped to \\_."""
+        assert escape_like("_") == "\\_"
+        assert escape_like("game_1") == "game\\_1"
+
+    def test_backslash_escaped(self):
+        r"""\ is escaped to \\."""
+        assert escape_like("a\\b") == "a\\\\b"
+
+    def test_combined_special_chars(self):
+        """Multiple special characters are all escaped."""
+        assert escape_like("50% off_sale") == "50\\% off\\_sale"
+
+
+# --------------------------------------------------------------------------- #
+# Library search – special characters                                           #
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def client_with_special_games(db_conn, client):
+    """Insert games with special characters in their names."""
+    db_conn.execute(
+        "INSERT INTO games (name, store, store_id) VALUES (?, ?, ?)",
+        ("100% Orange Juice", "steam", "282870"),
+    )
+    db_conn.execute(
+        "INSERT INTO games (name, store, store_id) VALUES (?, ?, ?)",
+        ("Pro_game", "steam", "99999"),
+    )
+    db_conn.execute(
+        "INSERT INTO games (name, store, store_id) VALUES (?, ?, ?)",
+        ("Normal Game", "steam", "11111"),
+    )
+    db_conn.commit()
+    # client fixture already sets up the DB override; just return it
+    return client
+
+
+class TestLibrarySearchSpecialChars:
+    def test_percent_search_returns_only_matching_game(self, client_with_special_games):
+        """Searching for % should match games that contain % in their name, not all games."""
+        resp = client_with_special_games.get("/library?search=%25")  # URL-encoded %
+        assert resp.status_code == 200
+        text = resp.text
+        # The game with % in its name should appear
+        assert "100% Orange Juice" in text
+        # Normal games should NOT appear
+        assert "Normal Game" not in text
+
+    def test_underscore_search_returns_only_matching_game(self, client_with_special_games):
+        """Searching for _ should not act as a wildcard; only exact matches are returned."""
+        resp = client_with_special_games.get("/library?search=Pro_game")
+        assert resp.status_code == 200
+        text = resp.text
+        assert "Pro_game" in text
+        # Normal Game has no underscore – should not match
+        assert "Normal Game" not in text
+
+    def test_plain_search_still_works(self, client_with_special_games):
+        """Regular search without special chars continues to work."""
+        resp = client_with_special_games.get("/library?search=Normal")
+        assert resp.status_code == 200
+        assert "Normal Game" in resp.text
+        assert "100% Orange Juice" not in resp.text
+
+    def test_search_too_long_returns_422(self, client_with_special_games):
+        """Search strings longer than 200 chars are rejected with HTTP 422."""
+        long_search = "a" * 201
+        resp = client_with_special_games.get(f"/library?search={long_search}")
+        assert resp.status_code == 422
+
+    def test_search_exactly_200_chars_is_accepted(self, client_with_special_games):
+        """Search strings of exactly 200 chars are accepted."""
+        search = "a" * 200
+        resp = client_with_special_games.get(f"/library?search={search}")
+        assert resp.status_code == 200

--- a/web/routes/library.py
+++ b/web/routes/library.py
@@ -12,7 +12,7 @@ from fastapi.templating import Jinja2Templates
 
 from ..dependencies import get_db
 from ..utils.filters import EXCLUDE_HIDDEN_FILTER, EXCLUDE_DUPLICATES_FILTER, PLAYTIME_LABELS
-from ..utils.helpers import parse_json_field, get_store_url, group_games_by_igdb
+from ..utils.helpers import parse_json_field, get_store_url, group_games_by_igdb, escape_like
 
 router = APIRouter()
 templates = Jinja2Templates(directory=Path(__file__).parent.parent / "templates")
@@ -29,7 +29,7 @@ def library(
     request: Request,
     stores: list[str] = Query(default=[]),
     genres: list[str] = Query(default=[]),
-    search: str = "",
+    search: str = Query(default="", max_length=200),
     sort: str = "name",
     order: str = "asc",
     exclude_streaming: bool = False,
@@ -55,13 +55,13 @@ def library(
         # Filter by genres, preferring genres_override if set
         genre_conditions = []
         for genre in genres:
-            genre_conditions.append("LOWER(COALESCE(genres_override, genres)) LIKE ?")
-            params.append(f'%"{genre.lower()}"%')
+            genre_conditions.append("LOWER(COALESCE(genres_override, genres)) LIKE ? ESCAPE '\\'")
+            params.append(f'%"{escape_like(genre.lower())}"%')
         query += " AND (" + " OR ".join(genre_conditions) + ")"
 
     if search:
-        query += " AND name LIKE ?"
-        params.append(f"%{search}%")
+        query += " AND name LIKE ? ESCAPE '\\'"
+        params.append(f"%{escape_like(search)}%")
 
     # Collection filter
     if collection:
@@ -336,7 +336,7 @@ def random_game(conn: sqlite3.Connection = Depends(get_db)):
 @router.get("/hidden", response_class=HTMLResponse)
 def hidden_games(
     request: Request,
-    search: str = "",
+    search: str = Query(default="", max_length=200),
     conn: sqlite3.Connection = Depends(get_db)
 ):
     """Page showing all hidden games."""
@@ -346,8 +346,8 @@ def hidden_games(
     params = []
 
     if search:
-        query += " AND name LIKE ?"
-        params.append(f"%{search}%")
+        query += " AND name LIKE ? ESCAPE '\\'"
+        params.append(f"%{escape_like(search)}%")
 
     query += " ORDER BY name COLLATE NOCASE ASC"
 
@@ -368,7 +368,7 @@ def hidden_games(
 @router.get("/removed", response_class=HTMLResponse)
 def removed_games(
     request: Request,
-    search: str = "",
+    search: str = Query(default="", max_length=200),
     conn: sqlite3.Connection = Depends(get_db)
 ):
     """Page showing all removed games."""
@@ -378,8 +378,8 @@ def removed_games(
     params = []
 
     if search:
-        query += " AND name LIKE ?"
-        params.append(f"%{search}%")
+        query += " AND name LIKE ? ESCAPE '\\'"
+        params.append(f"%{escape_like(search)}%")
 
     query += " ORDER BY name COLLATE NOCASE ASC"
 

--- a/web/utils/helpers.py
+++ b/web/utils/helpers.py
@@ -5,6 +5,26 @@ import json
 from urllib.parse import quote
 
 
+def escape_like(value: str) -> str:
+    """Escape special SQL LIKE wildcard characters in a search string.
+
+    Escapes backslash, percent, and underscore so they are treated as
+    literals rather than LIKE pattern characters.  The query must use
+    ``ESCAPE '\\'`` for the escaping to take effect in SQLite.
+
+    Args:
+        value: The raw user-supplied search string.
+
+    Returns:
+        The string with ``\\``, ``%``, and ``_`` escaped.
+
+    Example:
+        >>> escape_like("100%")
+        '100\\\\%'
+    """
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
 def parse_json_field(value):
     """Safely parse a JSON field."""
     if not value:


### PR DESCRIPTION
Fixes issue [#74](https://github.com/sam1am/backlogia/issues/74): escape SQL LIKE special characters in search queries

## Problem

Searching for `%` or `_` in the library search box produced wrong results:
- `%` → matched **all** games (SQL `LIKE` interprets `%` as "any sequence of characters")
- `_` → matched any single character instead of a literal underscore

Additionally, the `genres` filter had the same issue, and the `search` parameter had no length limit, leaving a potential DoS vector.

## Changes

### `web/utils/helpers.py`
- New `escape_like(value: str) -> str` utility function that escapes `\`, `%`, and `_` before injecting a value into a `LIKE` pattern.

### `web/routes/library.py`
- Applied `escape_like()` + `ESCAPE '\\'` on all three `name LIKE ?` queries: `/library`, `/hidden`, `/removed`.
- Applied `escape_like()` + `ESCAPE '\\'` on the `genres` `LIKE` filter as well.
- Added `max_length=200` via `Query(...)` on the `search` parameter in all three routes to prevent oversized inputs.

### `tests/test_search.py` *(new file)*
- Unit tests for `escape_like` covering `%`, `_`, `\`, and combinations.
- Integration tests against `/library` verifying that `%` only matches games whose name contains a literal `%`, that `_` is not treated as a wildcard, and that searches longer than 200 characters return HTTP 422.

## Notes

- **No SQL injection risk was found**: all user inputs are already passed as bound parameters (`?`). The only values interpolated directly into SQL (`sort`, `order`, `playtime_label`) are validated against whitelists before use.
- The fix is purely defensive: correct LIKE escaping + input size cap.
