### PR TITLE
Dockerfile: run as non-root user with fixed UID/GID 1000

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ COPY web/ ./web/
 # so host volume mounts can be chowned to match without inspecting the image first
 RUN mkdir -p /data \
     && groupadd -g 1000 appuser \
-    && useradd -u 1000 -g appuser -s /bin/sh appuser \
+    && useradd -u 1000 -g appuser -m -s /bin/sh appuser \
     && chown -R appuser:appuser /app /data
 
 USER appuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,14 @@ RUN pip install --no-cache-dir pycryptodome zstandard requests protobuf json5 \
 # Copy application code
 COPY web/ ./web/
 
-# Create data directory for the database
-RUN mkdir -p /data
+# Create data directory and non-root user with a fixed UID/GID (1000)
+# so host volume mounts can be chowned to match without inspecting the image first
+RUN mkdir -p /data \
+    && groupadd -g 1000 appuser \
+    && useradd -u 1000 -g appuser -s /bin/sh appuser \
+    && chown -R appuser:appuser /app /data
+
+USER appuser
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
## Changes

- Adds a dedicated `appuser` with UID/GID 1000 and switches to it with `USER appuser`
- Uses `-m` on `useradd` so the home directory is created — tools like `legendary-gl` and `nile` write configs to `$HOME/.config/` on first auth and fail with `PermissionError` without it
- Uses an explicit UID/GID (1000) rather than a system-assigned one so host volume mounts work predictably — a system-assigned UID can be anything (often 999), making it hard to `chown` the data directory on the host without inspecting the image

## Why

Running as root is unnecessary and violates container security best practices. An exploit in the web app or any dependency would have unrestricted access to the container filesystem.