### PR TITLE
Fix bookmarklet cross-origin requests when auth is enabled

### DIFF
--- a/web/main.py
+++ b/web/main.py
@@ -51,7 +51,19 @@ app = FastAPI(
     version="1.0.0",
 )
 
-# Add CORS middleware to allow bookmarklet requests from external sites
+# Middleware order: add_middleware is last-in/outermost in Starlette.
+# Auth must be added first (innermost) so CORS (added last/outermost) always
+# adds Access-Control-Allow-Origin headers — even to 401 responses from auth.
+# Without this, bookmarklet fetch() calls get a CORS error instead of a 401.
+if ENABLE_AUTH:
+    from .middleware import AuthMiddleware
+    from .services.auth_service import get_or_create_secret_key, cleanup_expired_sessions
+
+    actual_secret = SECRET_KEY or get_or_create_secret_key()
+    app.add_middleware(AuthMiddleware, secret_key=actual_secret)
+    cleanup_expired_sessions()
+
+# CORS must be outermost — added last so it wraps everything including auth.
 app.add_middleware(
     CORSMiddleware,
     allow_origins=[
@@ -65,15 +77,6 @@ app.add_middleware(
     allow_methods=["GET", "POST", "OPTIONS"],
     allow_headers=["*"],
 )
-
-# Conditionally add auth middleware (after CORS so CORS is the outer layer)
-if ENABLE_AUTH:
-    from .middleware import AuthMiddleware
-    from .services.auth_service import get_or_create_secret_key, cleanup_expired_sessions
-
-    actual_secret = SECRET_KEY or get_or_create_secret_key()
-    app.add_middleware(AuthMiddleware, secret_key=actual_secret)
-    cleanup_expired_sessions()
 
 # Initialize database on startup
 init_database()

--- a/web/middleware.py
+++ b/web/middleware.py
@@ -11,7 +11,7 @@ from .services.auth_service import validate_session, user_exists
 
 # Paths that are always accessible (no auth required)
 PUBLIC_PATHS = {"/login", "/setup", "/auth/login", "/auth/setup", "/auth/logout"}
-PUBLIC_PREFIXES = ("/static/",)
+PUBLIC_PREFIXES = ("/static/", "/api/import/")
 
 
 class AuthMiddleware(BaseHTTPMiddleware):

--- a/web/static/js/bookmarklet.js
+++ b/web/static/js/bookmarklet.js
@@ -173,6 +173,7 @@
                 var response = await fetch(LOCAL_URL + '/api/import/ubisoft', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
+                    credentials: 'include',
                     body: JSON.stringify({ games: uniqueGames })
                 });
                 var data = await response.json();
@@ -352,6 +353,7 @@
                 var response = await fetch(LOCAL_URL + '/api/import/gog', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
+                    credentials: 'include',
                     body: JSON.stringify({ games: uniqueGames })
                 });
                 var data = await response.json();


### PR DESCRIPTION
## Problem

With `ENABLE_AUTH=true`, the GOG and Ubisoft bookmarklets fail to POST game data to Backlogia. The bookmarklets run on external domains (`gog.com`, `ubisoft.com`) and can't reliably send the Backlogia session cookie cross-origin.

Two separate failure modes:

**1. CORS middleware order**
Starlette's `add_middleware` is last-in/outermost. CORS was added first (became innermost) and auth second (became outermost), so auth returned 401 responses before CORS could attach `Access-Control-Allow-Origin` headers. The browser rejected the response as a CORS failure and `fetch()` threw — showing "Failed to connect to Backlogia" in the overlay.

**2. Authentication required**
Even after fixing the order, `credentials: 'include'` is required for the browser to send cookies on cross-origin requests, and third-party cookie restrictions in modern browsers make this unreliable regardless.

## Fix

Three changes:

1. **CORS middleware order**: add auth first (innermost), CORS last (outermost) so CORS headers wrap all responses including auth rejections.

2. **`credentials: 'include'`** on the GOG and Ubisoft `fetch()` calls in `bookmarklet.js` — best-effort, works where third-party cookies are allowed.

3. **Exempt `/api/import/*` from auth** in the middleware. These endpoints are write-only and accept game data the user is deliberately sending from their own authenticated browser session on the external site. Exempting them is the only reliably cross-browser solution.